### PR TITLE
add low pass filtering on roll, pitch, and yaw rate control

### DIFF
--- a/src/modules/mc_rate_control/MulticopterRateControl.cpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.cpp
@@ -241,6 +241,7 @@ MulticopterRateControl::Run()
 			// run rate controller
 			const Vector3f att_control = _rate_control.update(rates, _rates_sp, angular_accel, dt, _maybe_landed || _landed);
 
+
 			// publish rate controller status
 			rate_ctrl_status_s rate_ctrl_status{};
 			_rate_control.getRateControlStatus(rate_ctrl_status);
@@ -277,6 +278,36 @@ MulticopterRateControl::Run()
 					}
 				}
 			}
+
+			// low pass filter the roll, pitch, and yaw actuator controls just before publishing
+			if(_param_mc_roll_cutoff.get() > 0.01f) {
+				_act_control_roll_filter.setParameters(dt, 1.f/(_param_mc_roll_cutoff.get() * M_TWOPI_F));
+
+				actuators.control[actuator_controls_s::INDEX_ROLL] = _act_control_roll_filter.update(actuators.control[actuator_controls_s::INDEX_ROLL]);
+			}
+			else {
+				_act_control_roll_filter.reset(actuators.control[actuator_controls_s::INDEX_ROLL]);
+			}
+
+			if(_param_mc_pitch_cutoff.get() > 0.01f) {
+				_act_control_pitch_filter.setParameters(dt, 1.f/(_param_mc_pitch_cutoff.get() * M_TWOPI_F));
+
+				actuators.control[actuator_controls_s::INDEX_PITCH] = _act_control_pitch_filter.update(actuators.control[actuator_controls_s::INDEX_PITCH]);
+			}
+			else {
+				_act_control_pitch_filter.reset(actuators.control[actuator_controls_s::INDEX_PITCH]);
+			}
+
+			if(_param_mc_yaw_cutoff.get() > 0.01f) {
+				_act_control_yaw_filter.setParameters(dt, 1.f/(_param_mc_yaw_cutoff.get() * M_TWOPI_F));
+
+				actuators.control[actuator_controls_s::INDEX_YAW] = _act_control_yaw_filter.update(actuators.control[actuator_controls_s::INDEX_YAW]);
+			}
+			else {
+				_act_control_yaw_filter.reset(actuators.control[actuator_controls_s::INDEX_YAW]);
+			}
+			// End low pass filtering of actuator controls
+
 
 			actuators.timestamp = hrt_absolute_time();
 			_actuators_0_pub.publish(actuators);

--- a/src/modules/mc_rate_control/MulticopterRateControl.hpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.hpp
@@ -35,6 +35,7 @@
 
 #include <RateControl.hpp>
 
+#include <lib/mathlib/math/filter/AlphaFilter.hpp>
 #include <lib/matrix/matrix/math.hpp>
 #include <lib/perf/perf_counter.h>
 #include <px4_platform_common/defines.h>
@@ -63,6 +64,7 @@
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/vehicle_thrust_setpoint.h>
 #include <uORB/topics/vehicle_torque_setpoint.h>
+
 
 using namespace time_literals;
 
@@ -143,6 +145,10 @@ private:
 	float _energy_integration_time{0.0f};
 	float _control_energy[4] {};
 
+	AlphaFilter<float> _act_control_roll_filter;
+	AlphaFilter<float> _act_control_pitch_filter;
+	AlphaFilter<float> _act_control_yaw_filter;
+
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::MC_ROLLRATE_P>) _param_mc_rollrate_p,
 		(ParamFloat<px4::params::MC_ROLLRATE_I>) _param_mc_rollrate_i,
@@ -177,7 +183,10 @@ private:
 
 		(ParamBool<px4::params::MC_BAT_SCALE_EN>) _param_mc_bat_scale_en,
 
-		(ParamInt<px4::params::CBRK_RATE_CTRL>) _param_cbrk_rate_ctrl
+		(ParamInt<px4::params::CBRK_RATE_CTRL>) _param_cbrk_rate_ctrl,
+		(ParamFloat<px4::params::MC_ROLL_CUTOFF>) _param_mc_roll_cutoff,
+		(ParamFloat<px4::params::MC_PITCH_CUTOFF>) _param_mc_pitch_cutoff,
+		(ParamFloat<px4::params::MC_YAW_CUTOFF>) _param_mc_yaw_cutoff
 	)
 
 	matrix::Vector3f _acro_rate_max;	/**< max attitude rates in acro mode */

--- a/src/modules/mc_rate_control/mc_rate_control_params.c
+++ b/src/modules/mc_rate_control/mc_rate_control_params.c
@@ -398,3 +398,39 @@ PARAM_DEFINE_FLOAT(MC_ACRO_SUPEXPOY, 0.7f);
  * @group Multicopter Rate Control
  */
 PARAM_DEFINE_INT32(MC_BAT_SCALE_EN, 0);
+
+/**
+ * First order low pass filter cutoff frequency for roll rate control
+ *
+ * 0 disables the filter
+ *
+ * @min 0
+ * @unit Hz
+ * @decimal 3
+ * @group Multicopter Rate Control
+ */
+PARAM_DEFINE_FLOAT(MC_ROLL_CUTOFF, 0.f);
+
+/**
+ * First order low pass filter cutoff frequency for pitch rate control
+ *
+ * 0 disables the filter
+ *
+ * @min 0
+ * @unit Hz
+ * @decimal 3
+ * @group Multicopter Rate Control
+ */
+PARAM_DEFINE_FLOAT(MC_PITCH_CUTOFF, 0.f);
+
+/**
+ * First order low pass filter cutoff frequency for yaw rate control
+ *
+ * 0 disables the filter
+ *
+ * @min 0
+ * @unit Hz
+ * @decimal 3
+ * @group Multicopter Rate Control
+ */
+PARAM_DEFINE_FLOAT(MC_YAW_CUTOFF, 0.f);


### PR DESCRIPTION

## Describe problem solved by this pull request
Enables better tuning of roll, pitch, and yaw rate control by adding option to add first order low pass filters to the outputs of these controllers.

## Describe your solution
Three first order low pass filters with cutoff frequencies controlled by parameters.  Feature is disabled by default.

## Describe possible alternatives
Option did not exist to filter roll, pitch, and yaw controllers independently.

## Test data / coverage
Uploaded and flew on modalai drone to test.

## Additional context
None.