### PR TITLE
reduce EV timeout to 200ms

### DIFF
--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -349,6 +349,7 @@ struct parameters {
 
 	const unsigned reset_timeout_max{7000000};	///< maximum time we allow horizontal inertial dead reckoning before attempting to reset the states to the measurement or change _control_status if the data is unavailable (uSec)
 	const unsigned no_aid_timeout_max{1000000};	///< maximum lapsed time from last fusion of a measurement that constrains horizontal velocity drift before the EKF will determine that the sensor is no longer contributing to aiding (uSec)
+	const unsigned ev_timeout_max{200000};		///< maximum lapsed time from last EV fusion of a measurement that constrains horizontal velocity drift before the EKF will determine that the sensor is no longer contributing to aiding (uSec)
 
 	int32_t valid_timeout_max{5000000};	///< amount of time spent inertial dead reckoning before the estimator reports the state estimates as invalid (uSec)
 

--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -378,7 +378,7 @@ void Ekf::controlExternalVisionFusion()
 		_hpos_pred_prev = _state.pos.xy();
 
 	} else if ((_control_status.flags.ev_pos || _control_status.flags.ev_vel ||  _control_status.flags.ev_yaw)
-		   && isTimedOut(_time_last_ext_vision, (uint64_t)_params.reset_timeout_max)) {
+		   && isTimedOut(_time_last_ext_vision, (uint64_t)_params.ev_timeout_max)) {
 
 		// Turn off EV fusion mode if no data has been received
 		stopEvFusion();


### PR DESCRIPTION
reduce timeout from 7s to 200ms when EV (VIO) data stops being received by EKF2. This makes fallback to manual mode during VIO failure quick and predictable.