### PR TITLE
Modalai autotune 1.13

### DIFF
--- a/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.cpp
+++ b/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.cpp
@@ -304,10 +304,9 @@ void McAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 		if (!(_param_mc_at_axes.get() & Axes::roll)) {
 			// Should not tune this axis, skip
 			_state = state::roll_pause;
-			_state_start_time = now;
+			_state_start_time = now - 3_s;
 		}
-
-		if (areAllSmallerThan(_sys_id.getVariances(), converged_thr)
+		else if (areAllSmallerThan(_sys_id.getVariances(), converged_thr)
 		    && ((now - _state_start_time) > 5_s)) {
 			copyGains(0);
 
@@ -337,10 +336,9 @@ void McAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 		if (!(_param_mc_at_axes.get() & Axes::pitch)) {
 			// Should not tune this axis, skip
 			_state = state::pitch_pause;
-			_state_start_time = now;
+			_state_start_time = now - 3_s;
 		}
-
-		if (areAllSmallerThan(_sys_id.getVariances(), converged_thr)
+		else if (areAllSmallerThan(_sys_id.getVariances(), converged_thr)
 		    && ((now - _state_start_time) > 5_s)) {
 			copyGains(1);
 			_state = state::pitch_pause;
@@ -368,10 +366,9 @@ void McAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 		if (!(_param_mc_at_axes.get() & Axes::yaw)) {
 			// Should not tune this axis, skip
 			_state = state::yaw_pause;
-			_state_start_time = now;
+			_state_start_time = now - 3_s;
 		}
-
-		if (areAllSmallerThan(_sys_id.getVariances(), converged_thr)
+		else if (areAllSmallerThan(_sys_id.getVariances(), converged_thr)
 		    && ((now - _state_start_time) > 5_s)) {
 			copyGains(2);
 			_state = state::yaw_pause;

--- a/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.cpp
+++ b/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.cpp
@@ -192,7 +192,8 @@ void McAutotuneAttitudeControl::Run()
 		// To compute the attitude gain, use the following empirical rule:
 		// "An error of 60 degrees should produce the maximum control output"
 		// or K_att * K_rate * rad(60) = 1
-		_attitude_p = math::constrain(1.f / (math::radians(60.f) * _kid(0)), 2.f, 6.5f);
+		// MODALAI: don't compute attitude P gain, it only ever selects 6.5 anyway
+		// _attitude_p = math::constrain(1.f / (math::radians(60.f) * _kid(0)), 2.f, 6.5f);
 
 		const Vector<float, 5> &coeff_var = _sys_id.getVariances();
 
@@ -212,7 +213,7 @@ void McAutotuneAttitudeControl::Run()
 		status.kc = _kid(0);
 		status.ki = _kid(1);
 		status.kd = _kid(2);
-		status.att_p = _attitude_p;
+		// status.att_p = _attitude_p;
 		rate_sp.copyTo(status.rate_sp);
 		status.state = static_cast<int>(_state);
 		_autotune_attitude_control_status_pub.publish(status);
@@ -539,7 +540,7 @@ void McAutotuneAttitudeControl::copyGains(int index)
 		_rate_k(index) = _kid(0);
 		_rate_i(index) = _kid(1);
 		_rate_d(index) = _kid(2);
-		_att_p(index) = _attitude_p;
+		//_att_p(index) = _attitude_p;
 	}
 }
 
@@ -554,13 +555,13 @@ bool McAutotuneAttitudeControl::areGainsGood() const
 		    || ((i == 2) && (_param_mc_at_axes.get() & Axes::yaw))) {
 			are_positive &= _rate_k(i) > 0.f
 						 && _rate_i(i) > 0.f
-						 && _rate_d(i) >= 0.f
-						 && _att_p(i) > 0.f;
+						 && _rate_d(i) >= 0.f;
+						// && _att_p(i) > 0.f;
 
 			are_small_enough &= _rate_k(i) < 0.5f
 							 && _rate_i(i) < 10.f
-							 && _rate_d(i) < 0.1f
-							 && _att_p(i) < 12.f;
+							 && _rate_d(i) < 0.1f;
+							// && _att_p(i) < 12.f;
 			}
 		}
 
@@ -569,18 +570,19 @@ bool McAutotuneAttitudeControl::areGainsGood() const
 
 void McAutotuneAttitudeControl::saveGainsToParams()
 {
+	// MODALAI don't set attitude rate P
 	// save as parallel form
 	if (_param_mc_at_axes.get() & Axes::roll) {
 		_param_mc_rollrate_p.set(_rate_k(0));
 		_param_mc_rollrate_k.set(1.f);
 		_param_mc_rollrate_i.set(_rate_k(0) * _rate_i(0));
 		_param_mc_rollrate_d.set(_rate_k(0) * _rate_d(0));
-		_param_mc_roll_p.set(_att_p(0));
+		// _param_mc_roll_p.set(_att_p(0));
 		_param_mc_rollrate_p.commit_no_notification();
 		_param_mc_rollrate_k.commit_no_notification();
 		_param_mc_rollrate_i.commit_no_notification();
 		_param_mc_rollrate_d.commit_no_notification();
-		_param_mc_roll_p.commit_no_notification();
+		// _param_mc_roll_p.commit_no_notification();
 	}
 
 	if (_param_mc_at_axes.get() & Axes::pitch) {
@@ -588,12 +590,12 @@ void McAutotuneAttitudeControl::saveGainsToParams()
 		_param_mc_pitchrate_k.set(1.f);
 		_param_mc_pitchrate_i.set(_rate_k(1) * _rate_i(1));
 		_param_mc_pitchrate_d.set(_rate_k(1) * _rate_d(1));
-		_param_mc_pitch_p.set(_att_p(1));
+		// _param_mc_pitch_p.set(_att_p(1));
 		_param_mc_pitchrate_p.commit_no_notification();
 		_param_mc_pitchrate_k.commit_no_notification();
 		_param_mc_pitchrate_i.commit_no_notification();
 		_param_mc_pitchrate_d.commit_no_notification();
-		_param_mc_pitch_p.commit_no_notification();
+		// _param_mc_pitch_p.commit_no_notification();
 	}
 
 	if (_param_mc_at_axes.get() & Axes::yaw) {
@@ -601,12 +603,12 @@ void McAutotuneAttitudeControl::saveGainsToParams()
 		_param_mc_yawrate_k.set(1.f);
 		_param_mc_yawrate_i.set(_rate_k(2) * _rate_i(2));
 		_param_mc_yawrate_d.set(_rate_k(2) * _rate_d(2));
-		_param_mc_yaw_p.set(_att_p(2));
+		// _param_mc_yaw_p.set(_att_p(2));
 		_param_mc_yawrate_p.commit_no_notification();
 		_param_mc_yawrate_k.commit_no_notification();
 		_param_mc_yawrate_i.commit_no_notification();
 		_param_mc_yawrate_d.commit_no_notification();
-		_param_mc_yaw_p.commit();
+		// _param_mc_yaw_p.commit();
 	}
 }
 

--- a/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.cpp
+++ b/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.cpp
@@ -302,7 +302,8 @@ void McAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 	case state::roll:
 		if (!(_param_mc_at_axes.get() & Axes::roll)) {
 			// Should not tune this axis, skip
-			_state = state::pitch;
+			_state = state::roll_pause;
+			_state_start_time = now;
 		}
 
 		if (areAllSmallerThan(_sys_id.getVariances(), converged_thr)
@@ -334,7 +335,8 @@ void McAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 	case state::pitch:
 		if (!(_param_mc_at_axes.get() & Axes::pitch)) {
 			// Should not tune this axis, skip
-			_state = state::yaw;
+			_state = state::pitch_pause;
+			_state_start_time = now;
 		}
 
 		if (areAllSmallerThan(_sys_id.getVariances(), converged_thr)
@@ -364,7 +366,8 @@ void McAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 	case state::yaw:
 		if (!(_param_mc_at_axes.get() & Axes::yaw)) {
 			// Should not tune this axis, skip
-			_state = state::verification;
+			_state = state::yaw_pause;
+			_state_start_time = now;
 		}
 
 		if (areAllSmallerThan(_sys_id.getVariances(), converged_thr)

--- a/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.hpp
+++ b/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.hpp
@@ -84,6 +84,12 @@ public:
 	int print_status() override;
 
 private:
+	enum Axes : int32_t {
+		roll = (1 << 0),
+		pitch = (1 << 1),
+		yaw = (1 << 2)
+	};
+
 	void Run() override;
 
 	void reset();
@@ -181,6 +187,7 @@ private:
 		(ParamFloat<px4::params::MC_AT_SYSID_AMP>) _param_mc_at_sysid_amp,
 		(ParamInt<px4::params::MC_AT_APPLY>) _param_mc_at_apply,
 		(ParamFloat<px4::params::MC_AT_RISE_TIME>) _param_mc_at_rise_time,
+		(ParamInt<px4::params::MC_AT_AXES>) _param_mc_at_axes,
 
 		(ParamFloat<px4::params::IMU_GYRO_CUTOFF>) _param_imu_gyro_cutoff,
 

--- a/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control_params.c
+++ b/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control_params.c
@@ -104,3 +104,22 @@ PARAM_DEFINE_INT32(MC_AT_APPLY, 1);
  * @group Autotune
  */
 PARAM_DEFINE_FLOAT(MC_AT_RISE_TIME, 0.14);
+
+/**
+ * Tuning axes selection
+ *
+ * Defines which axes will be tuned during the auto-tuning sequence
+ *
+ * Set bits in the following positions to enable:
+ * 0 : Roll
+ * 1 : Pitch
+ * 2 : Yaw
+ *
+ * @bit 0 roll
+ * @bit 1 pitch
+ * @bit 2 yaw
+ * @min 1
+ * @max 7
+ * @group Autotune
+ */
+PARAM_DEFINE_INT32(MC_AT_AXES, 3);


### PR DESCRIPTION
Allow individual axes to be tuned in the MC Autotune module. Also don't bother setting the attitude P since it only ever gets reset back to 6.5. This module tunes the rate controller and should leave attitude P alone.