### PR TITLE
add MPC_VZ_SRC param

### DIFF
--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -457,13 +457,22 @@ void MulticopterPositionControl::Run()
 			if (!PX4_ISFINITE(_setpoint.z)
 			    && PX4_ISFINITE(_setpoint.vz) && (fabsf(_setpoint.vz) > FLT_EPSILON)
 			    && PX4_ISFINITE(local_pos.z_deriv) && local_pos.z_valid && local_pos.v_z_valid) {
-				// A change in velocity is demanded and the altitude is not controlled.
-				// Set velocity to the derivative of position
-				// because it has less bias but blend it in across the landing speed range
-				//  <  MPC_LAND_SPEED: ramp up using altitude derivative without a step
-				//  >= MPC_LAND_SPEED: use altitude derivative
-				float weighting = fminf(fabsf(_setpoint.vz) / _param_mpc_land_speed.get(), 1.f);
-				states.velocity(2) = local_pos.z_deriv * weighting + local_pos.vz * (1.f - weighting);
+
+				if(_param_mpc_vz_src.get() == 0){
+					states.velocity(2) = local_pos.vz;
+				}
+				else if(_param_mpc_vz_src.get() == 1){
+					states.velocity(2) = local_pos.z_deriv;
+				}
+				else{
+					// A change in velocity is demanded and the altitude is not controlled.
+					// Set velocity to the derivative of position
+					// because it has less bias but blend it in across the landing speed range
+					//  <  MPC_LAND_SPEED: ramp up using altitude derivative without a step
+					//  >= MPC_LAND_SPEED: use altitude derivative
+					float weighting = fminf(fabsf(_setpoint.vz) / _param_mpc_land_speed.get(), 1.f);
+					states.velocity(2) = local_pos.z_deriv * weighting + local_pos.vz * (1.f - weighting);
+				}
 			}
 
 			_control.setState(states);

--- a/src/modules/mc_pos_control/MulticopterPositionControl.hpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.hpp
@@ -172,7 +172,8 @@ private:
 		(ParamFloat<px4::params::MPC_MAN_Y_TAU>)    _param_mpc_man_y_tau,
 
 		(ParamFloat<px4::params::MPC_XY_VEL_ALL>)   _param_mpc_xy_vel_all,
-		(ParamFloat<px4::params::MPC_Z_VEL_ALL>)    _param_mpc_z_vel_all
+		(ParamFloat<px4::params::MPC_Z_VEL_ALL>)    _param_mpc_z_vel_all,
+		(ParamInt<px4::params::MPC_VZ_SRC>)         _param_mpc_vz_src
 	);
 
 	control::BlockDerivative _vel_x_deriv; /**< velocity derivative in x */

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -859,3 +859,18 @@ PARAM_DEFINE_FLOAT(MPC_XY_VEL_ALL, -10.0f);
  * @group Multicopter Position Control
  */
 PARAM_DEFINE_FLOAT(MPC_Z_VEL_ALL, -3.0f);
+
+/**
+ * Velocity Source for Z Control
+ *
+ * The supported sources are:
+ * 0 vehicle_local_position vz
+ * 1 vehicle_local_position z_deriv
+ * 4 Blended
+ *
+ * @value 0 vz
+ * @value 1 z_deriv
+ * @value 2 Blend
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_INT32(MPC_VZ_SRC, 2);


### PR DESCRIPTION
new MPC_VZ_SRC param to select between vz, z_deriv, and blended velocity sources for altitude control. 