### PR TITLE
 M0065 param usage cleanup

### DIFF
--- a/boards/modalai/rb5-flight/voxl-px4.config
+++ b/boards/modalai/rb5-flight/voxl-px4.config
@@ -28,7 +28,10 @@ fi
 # We can only run on M0052 or M0054 so exit with error if that is not the case
 if [ $PLATFORM = "M0052" ]; then
     /bin/echo "Running on M0052"
-    if [ "$RC" == "CRSF" ]; then
+    if [ "$RC" == "CRSF_MAV" ]; then
+        /bin/echo "Error, crossfire not supported on M0052!"
+        exit 0
+    elif [ "$RC" == "CRSF_RAW" ]; then
         /bin/echo "Error, crossfire not supported on M0052!"
         exit 0
     fi
@@ -118,11 +121,11 @@ fi
 qshell icp10100 start -I -b 5
 
 # ESC driver
-# We start this even if there is a PX4IO module. If there is
-# a PX4IO (M0065) module it will be plugged into the RC port
-# and so this driver will output commands on an empty port.
-qshell modalai_esc start
-qshell mixer load /dev/uart_esc quad_x.main.mix
+if param compare UART_ESC_CONFIG 1; then
+     /bin/echo "Starting modalai_esc driver"
+    qshell modalai_esc start
+    qshell mixer load /dev/uart_esc quad_x.main.mix
+fi
 
 # APM power monitor
 qshell voxlpm start -X -b 2
@@ -181,11 +184,20 @@ else
             qshell px4io recovery
             qshell mixer load /dev/px4io quad_x_io.main.mix
 
-            sleep 1
-            qshell pwm rate -c 1234 -r 400
-			qshell pwm disarmed -c 1234 -p 900
-			qshell pwm min -c 1234 -p 1060
-			qshell pwm max -c 1234 -p 2000
+            PWM_RATE=`param show -q PWM_MAIN_RATE`
+            PWM_MAIN_DISARM=`param show -q PWM_MAIN_DISARM`
+            PWM_MAIN_MIN=`param show -q PWM_MAIN_MIN`
+            PWM_MAIN_MAX=`param show -q PWM_MAIN_MAX`
+
+            /bin/echo "  PWM_MAIN_RATE:   ${PWM_RATE}"
+            /bin/echo "  PWM_MAIN_DISARM: ${PWM_MAIN_DISARM}"
+            /bin/echo "  PWM_MAIN_MIN:   ${PWM_MAIN_MIN}"
+            /bin/echo "  PWM_MAIN_MAX: ${PWM_MAIN_MAX}"
+
+            qshell pwm rate -c 1234 -r ${PWM_RATE}
+            qshell pwm disarmed -c 1234 -p ${PWM_MAIN_DISARM}
+            qshell pwm min -c 1234 -p ${PWM_MAIN_MIN}
+            qshell pwm max -c 1234 -p ${PWM_MAIN_MAX}
             qshell pwm failsafe -c 1234 -p -1 -d /dev/px4io
         else
             /bin/echo "M0065 not detected, starting Spektrum RC driver"


### PR DESCRIPTION
 - use PWM params for setting up M0065 instead of hard coded values
 - don't enable UART esc unless param configed
 - unrelated to M0065: fix CRSF RC flags used to choose mode

