### PR TITLE
modal_io - updates for not mapping motors in command line tools, publish esc_status for commands line tools

### DIFF
--- a/src/drivers/actuators/modal_io/modal_io.cpp
+++ b/src/drivers/actuators/modal_io/modal_io.cpp
@@ -589,7 +589,7 @@ int ModalIo::custom_command(int argc, char *argv[])
 	}
 
 	if (!strcmp(verb, "reset")) {
-		if (esc_id < 4) {
+		if (esc_id < MODAL_IO_OUTPUT_CHANNELS) {
 			PX4_INFO("Reset ESC: %i", esc_id);
 			cmd.len = qc_esc_create_reset_packet(esc_id, cmd.buf, sizeof(cmd.buf));
 			cmd.response = false;
@@ -601,7 +601,7 @@ int ModalIo::custom_command(int argc, char *argv[])
 		}
 
 	} else if (!strcmp(verb, "version")) {
-		if (esc_id < 4) {
+		if (esc_id < MODAL_IO_OUTPUT_CHANNELS) {
 			PX4_INFO("Request version for ESC: %i", esc_id);
 			cmd.len = qc_esc_create_version_request_packet(esc_id, cmd.buf, sizeof(cmd.buf));
 			cmd.response = true;
@@ -614,7 +614,7 @@ int ModalIo::custom_command(int argc, char *argv[])
 		}
 
 	} else if (!strcmp(verb, "version-ext")) {
-		if (esc_id < 4) {
+		if (esc_id < MODAL_IO_OUTPUT_CHANNELS) {
 			PX4_INFO("Request extended version for ESC: %i", esc_id);
 			cmd.len = qc_esc_create_extended_version_request_packet(esc_id, cmd.buf, sizeof(cmd.buf));
 			cmd.response = true;
@@ -627,14 +627,14 @@ int ModalIo::custom_command(int argc, char *argv[])
 		}
 
 	} else if (!strcmp(verb, "tone")) {
-		if (0 < esc_id && esc_id < 16) {
+		if (esc_id < MODAL_IO_OUTPUT_CHANNELS) {
 			PX4_INFO("Request tone for ESC mask: %i", esc_id);
 			cmd.len = qc_esc_create_sound_packet(period, duration, power, esc_id, cmd.buf, sizeof(cmd.buf));
 			cmd.response = false;
 			return get_instance()->send_cmd_thread_safe(&cmd);
 
 		} else {
-			print_usage("Invalid ESC mask, use 1-15");
+			print_usage("Invalid ESC ID, use 0-3");
 			return 0;
 		}
 
@@ -656,42 +656,20 @@ int ModalIo::custom_command(int argc, char *argv[])
 		}
 
 	}  else if (!strcmp(verb, "rpm")) {
-		if (0 < esc_id && esc_id < 16) {
-			PX4_INFO("Request RPM for ESC bit mask: %i - RPM: %i", esc_id, rate);
-			int16_t rate_req[MODAL_IO_OUTPUT_CHANNELS];
-			int16_t outputs[MODAL_IO_OUTPUT_CHANNELS];
-			outputs[0] = (esc_id & 1) ? rate : 0;
-			outputs[1] = (esc_id & 2) ? rate : 0;
-			outputs[2] = (esc_id & 4) ? rate : 0;
-			outputs[3] = (esc_id & 8) ? rate : 0;
-
-			//the motor mapping is.. if I want to spin Motor 1 (1-4) then i need to provide non-zero rpm for motor map[m-1]
-
-			modal_io_params_t params;
-			ch_assign_t map[MODAL_IO_OUTPUT_CHANNELS];
-			get_instance()->load_params(&params, (ch_assign_t *)&map);
-
-			uint8_t id_fb_raw = 0;
+		if (esc_id < MODAL_IO_OUTPUT_CHANNELS) {
+			PX4_INFO("Request RPM for ESC ID: %i - RPM: %i", esc_id, rate);
+			int16_t rate_req[MODAL_IO_OUTPUT_CHANNELS] = {0, 0, 0, 0};
 			uint8_t id_fb = 0;
 
-			if (esc_id & 1) { id_fb_raw = 0; }
+			if (esc_id == 0xFF) {
+				rate_req[0] = rate;
+				rate_req[1] = rate;
+				rate_req[2] = rate;
+				rate_req[3] = rate;
 
-			else if (esc_id & 2) { id_fb_raw = 1; }
-
-			else if (esc_id & 4) { id_fb_raw = 2; }
-
-			else if (esc_id & 8) { id_fb_raw = 3; }
-
-			for (int i = 0; i < MODAL_IO_OUTPUT_CHANNELS; i++) {
-				int motor_idx = map[i].number - 1; // user defined mapping is 1-4, array is 0-3
-
-				if (motor_idx >= 0 && motor_idx < MODAL_IO_OUTPUT_CHANNELS) {
-					rate_req[i] = outputs[motor_idx] * map[i].direction;
-				}
-
-				if (motor_idx == id_fb_raw) {
-					id_fb = i;
-				}
+			} else {
+				rate_req[esc_id] = rate;
+				id_fb = esc_id;
 			}
 
 			cmd.len = qc_esc_create_rpm_packet4_fb(rate_req[0],
@@ -712,53 +690,31 @@ int ModalIo::custom_command(int argc, char *argv[])
 			cmd.repeat_delay_us = repeat_delay_us;
 			cmd.print_feedback  = true;
 
-			PX4_INFO("ESC map: %d %d %d %d", map[0].number, map[1].number, map[2].number, map[3].number);
-			PX4_INFO("feedback id debug: %i, %i", id_fb_raw, id_fb);
+			PX4_INFO("feedback id debug: %i", id_fb);
 			PX4_INFO("Sending UART ESC RPM command %i", rate);
 
 			return get_instance()->send_cmd_thread_safe(&cmd);
 
 		} else {
-			print_usage("Invalid ESC mask, use 1-15");
+			print_usage("Invalid ESC ID, use 0-3");
 			return 0;
 		}
 
 	} else if (!strcmp(verb, "pwm")) {
-		if (0 < esc_id && esc_id < 16) {
-			PX4_INFO("Request PWM for ESC mask: %i - PWM: %i", esc_id, rate);
-			int16_t rate_req[MODAL_IO_OUTPUT_CHANNELS];
-			int16_t outputs[MODAL_IO_OUTPUT_CHANNELS];
-			outputs[0] = (esc_id & 1) ? rate : 0;
-			outputs[1] = (esc_id & 2) ? rate : 0;
-			outputs[2] = (esc_id & 4) ? rate : 0;
-			outputs[3] = (esc_id & 8) ? rate : 0;
-
-			modal_io_params_t params;
-			ch_assign_t map[MODAL_IO_OUTPUT_CHANNELS];
-			get_instance()->load_params(&params, (ch_assign_t *)&map);
-
-			uint8_t id_fb_raw = 0;
+		if (esc_id < MODAL_IO_OUTPUT_CHANNELS) {
+			PX4_INFO("Request PWM for ESC ID: %i - PWM: %i", esc_id, rate);
+			int16_t rate_req[MODAL_IO_OUTPUT_CHANNELS] = {0, 0, 0, 0};
 			uint8_t id_fb = 0;
 
-			if (esc_id & 1) { id_fb_raw = 0; }
+			if (esc_id == 0xFF) {
+				rate_req[0] = rate;
+				rate_req[1] = rate;
+				rate_req[2] = rate;
+				rate_req[3] = rate;
 
-			else if (esc_id & 2) { id_fb_raw = 1; }
-
-			else if (esc_id & 4) { id_fb_raw = 2; }
-
-			else if (esc_id & 8) { id_fb_raw = 3; }
-
-			for (int i = 0; i < MODAL_IO_OUTPUT_CHANNELS; i++) {
-				int motor_idx = map[i].number - 1; // user defined mapping is 1-4, array is 0-3
-
-				if (motor_idx >= 0 && motor_idx < MODAL_IO_OUTPUT_CHANNELS) {
-					rate_req[i] = outputs[motor_idx] * map[i].direction;
-					PX4_INFO("rate_req[%d]=%d", i, rate_req[i]);
-				}
-
-				if (motor_idx == id_fb_raw) {
-					id_fb = i;
-				}
+			} else {
+				rate_req[esc_id] = rate;
+				id_fb = esc_id;
 			}
 
 			cmd.len = qc_esc_create_pwm_packet4_fb(rate_req[0],
@@ -779,10 +735,8 @@ int ModalIo::custom_command(int argc, char *argv[])
 			cmd.repeat_delay_us = repeat_delay_us;
 			cmd.print_feedback  = true;
 
-			PX4_INFO("ESC map: %d %d %d %d", map[0].number, map[1].number, map[2].number, map[3].number);
-			PX4_INFO("feedback id debug: %i, %i", id_fb_raw, id_fb);
+			PX4_INFO("feedback id debug: %i", id_fb);
 			PX4_INFO("Sending UART ESC power command %i", rate);
-
 
 			return get_instance()->send_cmd_thread_safe(&cmd);
 
@@ -1174,6 +1128,7 @@ bool ModalIo::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
 		_outputs_debug_pub.publish(actuator_outputs);
 
 	}
+
 	_esc_status_pub.publish(_esc_status);
 
 	perf_count(_output_update_perf);
@@ -1366,7 +1321,9 @@ void ModalIo::Run()
 					}
 
 					if (_current_cmd.response) {
-						read_response(&_current_cmd);
+						if (read_response(&_current_cmd) == 0) {
+							_esc_status_pub.publish(_esc_status);
+						}
 					}
 
 				} else {
@@ -1436,19 +1393,19 @@ $ todo
 	PRINT_MODULE_USAGE_PARAM_INT('i', 0, 0, 3, "ESC ID, 0-3", false);
 
 	PRINT_MODULE_USAGE_COMMAND_DESCR("rpm", "Closed-Loop RPM test control request");
-	PRINT_MODULE_USAGE_PARAM_INT('i', 1, 1, 15, "ESC ID bitmask, 1-15", false);
+	PRINT_MODULE_USAGE_PARAM_INT('i', 0, 0, 3, "ESC ID, 0-3", false);
 	PRINT_MODULE_USAGE_PARAM_INT('r', 0, -32768, 32768, "RPM, -32,768 to 32,768", false);
 	PRINT_MODULE_USAGE_PARAM_INT('n', 100, 0, 1<<31, "Command repeat count, 0 to INT_MAX", false);
 	PRINT_MODULE_USAGE_PARAM_INT('t', 10000, 0, 1<<31, "Delay between repeated commands (microseconds), 0 to INT_MAX", false);
 
 	PRINT_MODULE_USAGE_COMMAND_DESCR("pwm", "Open-Loop PWM test control request");
-	PRINT_MODULE_USAGE_PARAM_INT('i', 1, 1, 15, "ESC ID bitmask, 1-15", false);
+	PRINT_MODULE_USAGE_PARAM_INT('i', 0, 0, 3, "ESC ID, 0-3", false);
 	PRINT_MODULE_USAGE_PARAM_INT('r', 0, 0, 800, "Duty Cycle value, 0 to 800", false);
 	PRINT_MODULE_USAGE_PARAM_INT('n', 100, 0, 1<<31, "Command repeat count, 0 to INT_MAX", false);
 	PRINT_MODULE_USAGE_PARAM_INT('t', 10000, 0, 1<<31, "Delay between repeated commands (microseconds), 0 to INT_MAX", false);
 
 	PRINT_MODULE_USAGE_COMMAND_DESCR("tone", "Send tone generation request to ESC");
-	PRINT_MODULE_USAGE_PARAM_INT('i', 1, 1, 15, "ESC ID bitmask, 1-15", false);
+	PRINT_MODULE_USAGE_PARAM_INT('i', 0, 0, 3, "ESC ID, 0-3", false);
 	PRINT_MODULE_USAGE_PARAM_INT('p', 0, 0, 255, "Period of sound, inverse frequency, 0-255", false);
 	PRINT_MODULE_USAGE_PARAM_INT('d', 0, 0, 255, "Duration of the sound, 0-255, 1LSB = 13ms", false);
 	PRINT_MODULE_USAGE_PARAM_INT('v', 0, 0, 100, "Power (volume) of sound, 0-100", false);


### PR DESCRIPTION
- update modal_io command line args to use ESC HW ID instead of motor number