### PR TITLE
Voxl2 io protocol check update

### DIFF
--- a/src/drivers/voxl2_io/voxl2_io.cpp
+++ b/src/drivers/voxl2_io/voxl2_io.cpp
@@ -76,18 +76,18 @@ int Voxl2IO::init()
 		}
 	}
 
-	/* Verify connectivity and protocol version number */
-	if (get_version_info() < 0) {
-		PX4_ERR("Failed to detect voxl2_io protocol version.");
-		return PX4_ERROR;
-	} else {
-		if (_version_info.sw_version == VOXL2_IO_SW_PROTOCOL_VERSION && _version_info.hw_version == VOXL2_IO_HW_PROTOCOL_VERSION){
-			PX4_INFO("Detected M0065 protocol version. SW: %u HW: %u", _version_info.sw_version, _version_info.hw_version);
-		} else {
-			PX4_ERR("Detected incorrect M0065 protocol version. SW: %u HW: %u", _version_info.sw_version, _version_info.hw_version);
-			return PX4_ERROR;
-		}
-	}
+	// /* Verify connectivity and protocol version number */
+	// if (get_version_info() < 0) {
+	// 	PX4_ERR("Failed to detect voxl2_io protocol version.");
+	// 	return PX4_ERROR;
+	// } else {
+	// 	if (_version_info.sw_version == VOXL2_IO_SW_PROTOCOL_VERSION && _version_info.hw_version == VOXL2_IO_HW_PROTOCOL_VERSION){
+	// 		PX4_INFO("Detected M0065 protocol version. SW: %u HW: %u", _version_info.sw_version, _version_info.hw_version);
+	// 	} else {
+	// 		PX4_ERR("Detected incorrect M0065 protocol version. SW: %u HW: %u", _version_info.sw_version, _version_info.hw_version);
+	// 		return PX4_ERROR;
+	// 	}
+	// }
 
 	/* Getting initial parameter values */
 	ret = update_params();
@@ -182,9 +182,11 @@ int Voxl2IO::get_version_info()
 	int res = 0 ;
 	int header = -1 ;
 	int info_packet = -1;
-	int read_retries = 3;
+	int read_retries = 100;
 	int read_succeeded = 0;
 	Command cmd;	
+
+	if(!_need_version_info) return 0;
 
 	/* Request protocol version info from M0065 */
 	cmd.len = voxl2_io_create_version_request_packet(0, cmd.buf, VOXL2_IO_VERSION_INFO_SIZE);
@@ -195,11 +197,16 @@ int Voxl2IO::get_version_info()
 		_packets_sent++;
 	}
 
-	/* Read response */
-	px4_usleep(10000);
-	memset(&_read_buf, 0x00, READ_BUF_SIZE);
-	res = _uart_port->uart_read(_read_buf, READ_BUF_SIZE);
+	/* Read response, wait 500ms */
 	while(read_retries){
+		hrt_abstime now = hrt_absolute_time();
+		while (hrt_elapsed_time(&now) < 500000){
+			continue;
+		}
+		memset(&_read_buf, 0x00, READ_BUF_SIZE);
+		res = _uart_port->uart_read(_read_buf, READ_BUF_SIZE);
+
+		/* We got some kind of response, check if it's valid */
 		if (res) {
 			/* Get index of packer header */
 			for (int index = 0; index < READ_BUF_SIZE; ++index){
@@ -212,24 +219,24 @@ int Voxl2IO::get_version_info()
 				}
 			}
 
-			/* Try again in a bit if packet header not present yet... */
+			/* Bad data, try again... */
 			if (header == -1 || info_packet == -1){
-				if (_debug && header == -1) PX4_ERR("Failed to find voxl2_io packet header, trying again... retries left: %i", read_retries);
-				if (_debug && info_packet == -1) PX4_ERR("Failed to find version info packet header, trying again... retries left: %i", read_retries);
 				read_retries--;
 				flush_uart_rx();
+				if (_debug && header == -1) PX4_ERR("Failed to find voxl2_io packet header, trying again... retries left: %i", read_retries);
+				if (_debug && info_packet == -1) PX4_ERR("Failed to find version info packet header, trying again... retries left: %i", read_retries);
 				if (_uart_port->uart_write(cmd.buf, cmd.len) != cmd.len) {
 					PX4_ERR("Failed to send version info packet");
 				} else {
 					_bytes_sent+=cmd.len;
 					_packets_sent++;
-					px4_usleep(2000);
 				}
 				continue;
 			}
 
 			/* Check if we got a valid packet...*/
 			if (parse_response(&_read_buf[header], (uint8_t)VOXL2_IO_VERSION_INFO_SIZE)){
+				/* If we get here then the packet was not valid, try again... */
 				if(_debug) {
 					PX4_ERR("Error parsing version info packet");
 					PX4_INFO_RAW("[%02x,%02x,%02x,%02x,%02x,%02x,%02x,%02x,%02x,%02x,%02x,%02x,%02x,%02x,%02x,%02x,%02x,%02x,%02x,%02x,%02x,%02x,%02x,%02x,%02x,%02x,%02x,%02x,%02x,%02x]\n",
@@ -248,27 +255,30 @@ int Voxl2IO::get_version_info()
 				} else {
 					_bytes_sent+=cmd.len;
 					_packets_sent++;
-					px4_usleep(2000);
 				}
 				break;
 
+			/* We got a valid response! Update version info */
 			}  else {
 				memcpy(&_version_info, &_read_buf[header], sizeof(VOXL2_IO_VERSION_INFO));
 				read_succeeded = 1;
 				break;
 			}
+
+		/* We didn't get a response from Voxl2 IO board, try again... */
 		} else {
 			read_retries--;
+			PX4_ERR("Failed to receive version info, %i retries left...", read_retries);
 			if (_uart_port->uart_write(cmd.buf, cmd.len) != cmd.len) {
 				PX4_ERR("Failed to send version info packet");
 			} else {
 				_bytes_sent+=cmd.len;
 				_packets_sent++;
-				px4_usleep(2000);
 			}
 		}
 	}
 
+	/* Failed to read version info in alloted time */
 	if (! read_succeeded){
 		return -EIO;
 	}
@@ -574,6 +584,39 @@ void Voxl2IO::Run()
 	}
 
 	perf_begin(_cycle_perf);
+
+	/* Verify connectivity */
+	if (_need_version_info && get_version_info() < 0) {
+		PX4_ERR("Failed to detect voxl2_io protocol version.");
+	} 
+
+	/* Verify protocol version info */
+	if (_need_version_info){
+		if(_version_info.sw_version == VOXL2_IO_SW_PROTOCOL_VERSION && _version_info.hw_version == VOXL2_IO_HW_PROTOCOL_VERSION){
+			_need_version_info = false;
+			PX4_INFO("Detected M0065 protocol version. SW: %u HW: %u", _version_info.sw_version, _version_info.hw_version);
+		} else if (_protocol_read_retries > 0) {
+			PX4_ERR("Detected incorrect M0065 protocol version. SW: %u HW: %u. Retrying, %i attempts left...", _version_info.sw_version, _version_info.hw_version, --_protocol_read_retries);
+			return;
+		} else {
+			PX4_ERR("Retries exhausted, exiting now.");
+			request_stop();
+			return;
+		}
+	}
+
+	// Infinite loop version.. will remove soon.. still validating 
+	// if (_need_version_info){
+	// 	if(_version_info.sw_version == VOXL2_IO_SW_PROTOCOL_VERSION && _version_info.hw_version == VOXL2_IO_HW_PROTOCOL_VERSION){
+	// 		_need_version_info = false;
+	// 		PX4_INFO("Detected M0065 protocol version. SW: %u HW: %u", _version_info.sw_version, _version_info.hw_version);
+	// 	} else {
+	// 		PX4_ERR("Detected incorrect M0065 protocol version. SW: %u HW: %u. Retrying...", _version_info.sw_version, _version_info.hw_version);
+	// 		return;
+	// 	} 
+	// 	_protocol_read_retries--;
+	// }
+
 
 	/* Handle RC */
 	if (_rc_mode == RC_MODE::SCAN){
@@ -968,7 +1011,8 @@ int Voxl2IO::print_status()
 	PX4_INFO("Max update rate: %u Hz", 1000000/_current_update_interval);
 	PX4_INFO("PWM Rate: 400 Hz");	// Only support 400 Hz for now
 	PX4_INFO("Outputs on: %s", _pwm_on ? "yes" : "no");
-	PX4_INFO("FW version: v%u.%u", _version_info.sw_version, _version_info.hw_version);
+	PX4_INFO("SW version: %u", _version_info.sw_version);
+	PX4_INFO("HW version: %u", _version_info.hw_version);
 	PX4_INFO("RC Type: SBUS");		// Only support SBUS through M0065 for now 
 	PX4_INFO("RC Connected: %s", hrt_absolute_time() - _rc_last_valid > 500000 ? "no" : "yes");
 	PX4_INFO("RC Packets Received: %" PRIu16, _sbus_total_frames);

--- a/src/drivers/voxl2_io/voxl2_io.cpp
+++ b/src/drivers/voxl2_io/voxl2_io.cpp
@@ -585,18 +585,14 @@ void Voxl2IO::Run()
 
 	perf_begin(_cycle_perf);
 
-	/* Verify connectivity */
-	if (_need_version_info && get_version_info() < 0) {
-		PX4_ERR("Failed to detect voxl2_io protocol version.");
-	} 
-
 	/* Verify protocol version info */
 	if (_need_version_info){
-		if(_version_info.sw_version == VOXL2_IO_SW_PROTOCOL_VERSION && _version_info.hw_version == VOXL2_IO_HW_PROTOCOL_VERSION){
+		if (get_version_info() < 0) PX4_ERR("Failed to detect voxl2_io protocol version.");
+		if (_version_info.sw_version == VOXL2_IO_SW_PROTOCOL_VERSION && _version_info.hw_version == VOXL2_IO_HW_PROTOCOL_VERSION){
 			_need_version_info = false;
 			PX4_INFO("Detected M0065 protocol version. SW: %u HW: %u", _version_info.sw_version, _version_info.hw_version);
-		} else if (_protocol_read_retries > 0) {
-			PX4_ERR("Detected incorrect M0065 protocol version. SW: %u HW: %u. Retrying, %i attempts left...", _version_info.sw_version, _version_info.hw_version, --_protocol_read_retries);
+		} else if (_protocol_read_retries > 0) {	// If Voxl2 IO gets powered up late, the initial values read are sometimes garbage
+			PX4_ERR("Detected incorrect M0065 protocol version. SW: %u HW: %u. Retrying, %i attempts left...", _version_info.sw_version, _version_info.hw_version, _protocol_read_retries--);
 			return;
 		} else {
 			PX4_ERR("Retries exhausted, exiting now.");
@@ -604,19 +600,6 @@ void Voxl2IO::Run()
 			return;
 		}
 	}
-
-	// Infinite loop version.. will remove soon.. still validating 
-	// if (_need_version_info){
-	// 	if(_version_info.sw_version == VOXL2_IO_SW_PROTOCOL_VERSION && _version_info.hw_version == VOXL2_IO_HW_PROTOCOL_VERSION){
-	// 		_need_version_info = false;
-	// 		PX4_INFO("Detected M0065 protocol version. SW: %u HW: %u", _version_info.sw_version, _version_info.hw_version);
-	// 	} else {
-	// 		PX4_ERR("Detected incorrect M0065 protocol version. SW: %u HW: %u. Retrying...", _version_info.sw_version, _version_info.hw_version);
-	// 		return;
-	// 	} 
-	// 	_protocol_read_retries--;
-	// }
-
 
 	/* Handle RC */
 	if (_rc_mode == RC_MODE::SCAN){

--- a/src/drivers/voxl2_io/voxl2_io.hpp
+++ b/src/drivers/voxl2_io/voxl2_io.hpp
@@ -147,6 +147,8 @@ private:
 	static constexpr uint16_t VOXL2_IO_VERSION_INFO_SIZE = 6;
 	static constexpr uint16_t VOXL2_IO_SW_PROTOCOL_VERSION = 1;
 	static constexpr uint16_t VOXL2_IO_HW_PROTOCOL_VERSION = 35;
+	int  _protocol_read_retries{3};
+	bool _need_version_info{true};
 	VOXL2_IO_VERSION_INFO _version_info;
 
 	/* Module update interval */


### PR DESCRIPTION
# Changes
Updated the voxl2_io driver protocol version check on driver startup. The protocol version check was moved from the init() function to the Run() function so that querying and waiting for protocol version information doesn't hold up px4 from continuing its start up sequence. I observed that when the protocol version check was in the init() function, px4 would sit and wait until either we got the info or we timed out. This resulted in no other drivers being able to start while this was happening, px4 was essentially dead in the water waiting for this protocol version check to complete.

Rather than timing out after 3 attempts to get protocol version information, now the driver will call the get_version_info() function a maximum of 3 times and each time the function sends 100 requests before failing that particular attempt. I had observed while testing that if the Voxl2 IO board is powered up after px4 is running, sometimes the response that voxl2_io driver receives contains garbage values (I.e. it would sometimes read info like: SW version 16203 and HW version 10398). The get_version_info() function is called multiple times before timing out in order to account for this or similar possible scenarios.

If the driver times out and doesn't receive protocol version info, the driver will be stopped. 

## Testing 
Tested using px4 config variables RC=M0065_SBUS and ESC=VOXL2_IO_PWM_ESC
- Set up as standard, voxl2 IO plugged into J18. Protocol version check works as intended, did not see any errors.
    - Also tested this on J19, worked fine as well.
- Set up voxl2 IO with TX/RX connected to voxl2 but power from external source. Powered on voxl2 IO AFTER px4 is running (to simulate voxl2_io driver starting before voxl2 IO is ready to respond to version info request) and this works as well.
- Observe driver timeout and stop itself after attempts are exhausted