### PR TITLE
add params and set flags in case of ESC warn and over temperature events

### DIFF
--- a/src/drivers/actuators/voxl_esc/voxl_esc.hpp
+++ b/src/drivers/actuators/voxl_esc/voxl_esc.hpp
@@ -150,6 +150,8 @@ private:
 		int32_t		direction_map[VOXL_ESC_OUTPUT_CHANNELS] {1, 1, 1, 1};
 		int32_t		verbose_logging{0};
 		int32_t 	publish_battery_status{0};
+		int32_t 	esc_warn_temp_threshold{0};
+		int32_t 	esc_over_temp_threshold{0};
 	} voxl_esc_params_t;
 
 	struct EscChan {

--- a/src/drivers/actuators/voxl_esc/voxl_esc_params.c
+++ b/src/drivers/actuators/voxl_esc/voxl_esc_params.c
@@ -232,3 +232,34 @@ PARAM_DEFINE_INT32(VOXL_ESC_VLOG, 0);
  * @max 1
  */
 PARAM_DEFINE_INT32(VOXL_ESC_PUB_BST, 1);
+
+
+/**
+ * UART ESC Temperature Warning Threshold (Degrees C)
+ * 
+ * Only applicable to ESCs that report temperature
+ *
+ * @reboot_required true
+ *
+ * @group VOXL ESC
+ * @value 0 - Disabled
+ * @min 0
+ * @max 200
+ */
+PARAM_DEFINE_INT32(VOXL_ESC_T_WARN, 0);
+
+
+/**
+ * UART ESC Over-Temperature Threshold (Degrees C)
+ * 
+ * Only applicable to ESCs that report temperature
+ *
+ * @reboot_required true
+ *
+ * @group VOXL ESC
+ * @value 0 - Disabled
+ * @min 0
+ * @max 200
+ */
+PARAM_DEFINE_INT32(VOXL_ESC_T_OVER, 0);
+


### PR DESCRIPTION
- Added two PX4 params VOXL_ESC_T_WARN and VOXL_ESC_T_OVER to voxl_esc ESC driver.
- If the params are set to zero, there is no effect
- If the params are greater than zero, they act as threshold temperatures (in degrees C) for setting the WARNING and OVERTEMPERATURE flags in esc_status message for each appropriate ESC ID.
- the warning and over-temperature flags being set result in an ERROR message printed in PX4 console but they should also result in the user being alerted and prompted to land
- suggested values are 90 deg C for VOXL_ESC_T_WARN and 105 for VOXL_ESC_T_OVER
