### PR TITLE
Fix SITL Build

### DIFF
--- a/platforms/common/include/px4_platform_common/board_common.h
+++ b/platforms/common/include/px4_platform_common/board_common.h
@@ -355,6 +355,22 @@ typedef enum PX4_SOC_ARCH_ID_t {
 
 } PX4_SOC_ARCH_ID_t;
 
+#define PX4_SOC_ARCH_ID_UNUSED         0x0000
+#define PX4_SOC_ARCH_ID_STM32F4        0x0001
+#define PX4_SOC_ARCH_ID_STM32F7        0x0002
+#define PX4_SOC_ARCH_ID_KINETISK66     0x0003
+#define PX4_SOC_ARCH_ID_SAMV7          0x0004
+#define PX4_SOC_ARCH_ID_NXPIMXRT1062   0x0005
+#define PX4_SOC_ARCH_ID_STM32H7        0x0006
+#define PX4_SOC_ARCH_ID_NXPS32K146     0x0007
+#define PX4_SOC_ARCH_ID_NXPS32K344     0x0008
+#define PX4_SOC_ARCH_ID_EAGLE          0x1001
+#define PX4_SOC_ARCH_ID_QURT           0x1002
+#define PX4_SOC_ARCH_ID_RPI            0x1004
+#define PX4_SOC_ARCH_ID_SIM            0x1005
+#define PX4_SOC_ARCH_ID_SITL           0x1006
+#define PX4_SOC_ARCH_ID_BBBLUE         0x1008
+#define PX4_SOC_ARCH_ID_VOXL2          0x100A
 
 /* UUID
  *

--- a/platforms/posix/src/px4/common/main.cpp
+++ b/platforms/posix/src/px4/common/main.cpp
@@ -500,11 +500,11 @@ void register_sig_handler()
 	sigaction(SIGPIPE, &sig_pipe, nullptr);
 }
 
-extern "C" bool muorb_kill_slpi(void);
+// extern "C" bool muorb_kill_slpi(void);
 
 void sig_int_handler(int sig_num)
 {
-	muorb_kill_slpi();
+	// muorb_kill_slpi();
 	fflush(stdout);
 	printf("\nPX4 Exiting in sig_int_handler\n");
 	fflush(stdout);

--- a/src/modules/load_mon/LoadMon.cpp
+++ b/src/modules/load_mon/LoadMon.cpp
@@ -232,7 +232,9 @@ void LoadMon::cpuload()
 	} else {
 		double total, idle{0};
 		char cpu_line[256];
-		fgets(cpu_line, sizeof(line), stat_file);
+		if (fgets(cpu_line, sizeof(line), stat_file) == NULL) {
+			return;
+		}
 
 		// Assuming the first line in /proc/stat is the line with overall CPU usage
 		char *token = strtok(cpu_line, " ");
@@ -246,7 +248,7 @@ void LoadMon::cpuload()
 					idle = atof(token);
 				}
 				i++;
-			}	
+			}
 		}
 
 		total = total_time;


### PR DESCRIPTION
I would like to be able to run the SITL targets using the same PX4 repository that I use to flash my voxl2.  Currently the modalai fork of PX4 does not build for any SITL target. This PR contains the changes I required to build PX4. I have not tested on hardware and I would appreciate some guidance on better methods to be able to retain support for SITL. 


