### PR TITLE
fixed rc input lag when all pwm outputs are disabled

### DIFF
--- a/src/drivers/voxl2_io/voxl2_io.cpp
+++ b/src/drivers/voxl2_io/voxl2_io.cpp
@@ -43,6 +43,10 @@ Voxl2IO::Voxl2IO() :
 	_mixing_output.setMaxNumOutputs(VOXL2_IO_OUTPUT_CHANNELS);
 	_uart_port = new Voxl2IoSerial();
 	voxl2_io_packet_init(&_voxl2_io_packet);
+
+	//set low rate scheduling interval to 200hz so that RC can be updated even if all actuators are disabled
+	//otherwise, the default low rate scheduling interval is 300ms and RC packets are delayed and lost
+	_mixing_output.setLowrateSchedulingInterval(5_ms);
 }
 
 Voxl2IO::~Voxl2IO()
@@ -729,6 +733,10 @@ int Voxl2IO::custom_command(int argc, char *argv[])
 			return -1;
 		}
 		return get_instance()->calibrate_escs();
+	}
+
+	if (!strcmp(verb,"enable_debug")){
+		get_instance()->_debug = true;
 	}
 
 	return print_usage("unknown custom command");


### PR DESCRIPTION
set the minimum scheduling interval for voxl2_io module to 5ms in order to fix rc input lag when all pwm outputs are disabled