### PR TITLE
Add VIO quality metric to MSP DP based OSD 

### DIFF
--- a/boards/modalai/voxl2/src/drivers/msp_dp_osd/msp_dp_osd.cpp
+++ b/boards/modalai/voxl2/src/drivers/msp_dp_osd/msp_dp_osd.cpp
@@ -536,6 +536,7 @@ int MspDPOsd::custom_command(int argc, char *argv[])
 	int ch;
 	int row{0};
 	int col{0};
+	size_t msg_len{0};
 	char cmd_band[1]{'R'};	// Default to Raceband
 	uint8_t cmd_channel{0};	// Channel 1 (R1)
 	uint8_t cmd_power{1};	// Default 25mW
@@ -587,11 +588,13 @@ int MspDPOsd::custom_command(int argc, char *argv[])
 			break;
 
 		case 's':
-			if (strlen(myoptarg) > MSP_OSD_MAX_STRING_LENGTH){
-				PX4_WARN("String length too long, max string length: %i. Message may be truncated.", MSP_OSD_MAX_STRING_LENGTH);
+			msg_len = strlen(myoptarg);
+			if (msg_len > MSP_OSD_MAX_STRING_LENGTH){
+				PX4_WARN("String length (%lu) too long, max string length: %i. Message may be truncated.", msg_len, MSP_OSD_MAX_STRING_LENGTH);
+				msg_len = MSP_OSD_MAX_STRING_LENGTH;
 			}
-			PX4_INFO("Got string: %s, Length: %lu", myoptarg, strlen(myoptarg));
-			strncpy(cmd_string, myoptarg, strlen(myoptarg) + 1);
+			PX4_INFO("Got string: %s, Length: %lu", myoptarg, msg_len);
+			strncpy(cmd_string, myoptarg, msg_len + 1);
 			break;
 
 		case 'b':

--- a/boards/modalai/voxl2/src/drivers/msp_dp_osd/msp_dp_osd.hpp
+++ b/boards/modalai/voxl2/src/drivers/msp_dp_osd/msp_dp_osd.hpp
@@ -55,6 +55,7 @@
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/vehicle_odometry.h>
 
 #include "MspDPV1.hpp"
 #include <drivers/osd/msp_osd/MessageDisplay/MessageDisplay.hpp>
@@ -127,6 +128,7 @@ private:
 	uORB::Subscription _vehicle_gps_position_sub{ORB_ID(vehicle_gps_position)};
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
+	uORB::Subscription _vehicle_visual_odometry_sub{ORB_ID(vehicle_visual_odometry)};
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
@@ -158,6 +160,8 @@ private:
 		int32_t		crosshair_row;
 		int32_t		heading_col;
 		int32_t		heading_row;
+		int32_t		vio_col;
+		int32_t		vio_row;
 	} msp_dp_osd_params_t;
 
 	// parameters

--- a/boards/modalai/voxl2/src/drivers/msp_dp_osd/msp_dp_params.c
+++ b/boards/modalai/voxl2/src/drivers/msp_dp_osd/msp_dp_params.c
@@ -296,6 +296,29 @@ PARAM_DEFINE_INT32(OSD_HDG_COL, -1);
 PARAM_DEFINE_INT32(OSD_HDG_ROW, -1);
 
 /**
+ * OSD VIO quality row 
+ *
+ * Selects which row to place VIO quality element in.
+ *
+ * @group OSD
+ * @min -1
+ * @max 17
+ */
+PARAM_DEFINE_INT32(OSD_VIO_COL, -1);
+
+/**
+ *OSD VIO quality column 
+ *
+ * Selects which column to place VIO quality element in.
+ *
+ * @group OSD
+ * @min -1
+ * @max 49
+ */
+PARAM_DEFINE_INT32(OSD_VIO_ROW, -1);
+
+
+/**
  * VTX channel
  *
  * Selects which VTX channel to broadcast on.

--- a/boards/modalai/voxl2/target/voxl-px4-start
+++ b/boards/modalai/voxl2/target/voxl-px4-start
@@ -257,9 +257,12 @@ mavlink boot_complete
 if [ "$OSD" == "ENABLE" ] || [ "$OSD" == "DJI" ]; then
     /bin/echo "Starting DJI OSD driver"
     msp_osd start -d /dev/ttyHS1
-elif [ "$OSD" == "HDZERO" ]; then 
-    /bin/echo "Starting HDZero OSD driver"
+elif [ "$OSD" == "HDZERO" ] && [ "$PLATFORM" == "M0054" ]; then 
+    /bin/echo "Starting HDZero OSD driver for M0054"
     msp_dp_osd start -d /dev/ttyHS1
+elif [ "$OSD" == "HDZERO" ] && [ "$PLATFORM" == "M0104" ]; then
+	/bin/echo "Starting HDZero OSD driver for M0104"
+	msp_dp_osd start -d /dev/ttyHS0
 fi
 
 # Start optional EXTRA_STEPS


### PR DESCRIPTION
1. Added OSD elements related to VIO quality metric ("VIO" header, vio quality digit, progress bar). 
2. Added parameters for location (column/row on the OSD canvas), default is -1 (off screen), same as other OSD element defaults.
3. Added support for voxl2-mini as requested for Stinger.
4. Updated instructions for the custom command to arbitrary write strings to OSD (useful for development).
5. Tested and confirmed all features/updates listed above work on bench top using Starling and Stinger drones.

- Note: Parameters for OSD element locations aren't currently in voxl-px4-params, the default values in the msp_dp_osd driver are set to place all elements off screen (value of -1). For development of this feature, I added them manually. The parameters I used are attached here as .txt file (not able to attach .params file here).

[msp_dp_osd_params.txt](https://github.com/user-attachments/files/16169776/msp_dp_osd_params.txt)
