### PR TITLE
Enable MSP DP OSD driver for DJI VTX

### DIFF
--- a/boards/modalai/voxl2/target/voxl-px4-start
+++ b/boards/modalai/voxl2/target/voxl-px4-start
@@ -257,14 +257,11 @@ mavlink boot_complete
 if [ "$OSD" == "ENABLE" ] || [ "$OSD" == "DJI" ]; then
     /bin/echo "Starting DJI OSD driver"
     msp_osd start -d /dev/ttyHS1
-elif [ "$OSD" == "DJI_MSP_DP" ]; then 
-    /bin/echo "Starting DJI MSP DP OSD driver"
+elif [ "$PLATFORM" == "M0054" ] && [ "$OSD" == "HDZERO" ] || [ "$OSD" == "DJI_MSP_DP" ]; then 
+    /bin/echo "Starting $OSD OSD driver for $PLATFORM"
     msp_dp_osd start -d /dev/ttyHS1
-elif [ "$OSD" == "HDZERO" ] && [ "$PLATFORM" == "M0054" ]; then 
-    /bin/echo "Starting HDZero OSD driver for M0054"
-    msp_dp_osd start -d /dev/ttyHS1
-elif [ "$OSD" == "HDZERO" ] && [ "$PLATFORM" == "M0104" ]; then
-	/bin/echo "Starting HDZero OSD driver for M0104"
+elif [ "$PLATFORM" == "M0104" ] && [ "$OSD" == "HDZERO" ] || [ "$OSD" == "DJI_MSP_DP" ] ; then
+	/bin/echo "Starting $OSD OSD driver for $PLATFORM"
 	msp_dp_osd start -d /dev/ttyHS0
 fi
 

--- a/boards/modalai/voxl2/target/voxl-px4-start
+++ b/boards/modalai/voxl2/target/voxl-px4-start
@@ -257,6 +257,9 @@ mavlink boot_complete
 if [ "$OSD" == "ENABLE" ] || [ "$OSD" == "DJI" ]; then
     /bin/echo "Starting DJI OSD driver"
     msp_osd start -d /dev/ttyHS1
+elif [ "$OSD" == "DJI_MSP_DP" ]; then 
+    /bin/echo "Starting DJI MSP DP OSD driver"
+    msp_dp_osd start -d /dev/ttyHS1
 elif [ "$OSD" == "HDZERO" ] && [ "$PLATFORM" == "M0054" ]; then 
     /bin/echo "Starting HDZero OSD driver for M0054"
     msp_dp_osd start -d /dev/ttyHS1


### PR DESCRIPTION
Enable support for MSP DP OSD driver when using DJI VTX/Goggles with MSP Display Port protocol.
Enabled for both voxl2 and voxl2 mini. Added new value `DJI_MSP_DP` for `OSD` field in voxl-px4.conf which will start the msp_dp_osd driver on the correct port for either the voxl2 or voxl2 mini. Maybe a good idea to add this to the info in the config file as well