### PR TITLE
BUG: Drivers: QURT I2C do not use a static mutex for all I2C drivers

### DIFF
--- a/src/lib/drivers/device/qurt/I2C.cpp
+++ b/src/lib/drivers/device/qurt/I2C.cpp
@@ -55,8 +55,6 @@ I2C::_config_i2c_bus_func_t  I2C::_config_i2c_bus  = NULL;
 I2C::_set_i2c_address_func_t I2C::_set_i2c_address = NULL;
 I2C::_i2c_transfer_func_t    I2C::_i2c_transfer    = NULL;
 
-pthread_mutex_t I2C::_mutex = PTHREAD_MUTEX_INITIALIZER;
-
 I2C::I2C(uint8_t device_type, const char *name, const int bus, const uint16_t address, const uint32_t frequency) :
 	CDev(name, nullptr),
 	_frequency(frequency / 1000)
@@ -68,6 +66,8 @@ I2C::I2C(uint8_t device_type, const char *name, const int bus, const uint16_t ad
 	_device_id.devid_s.bus_type = DeviceBusType_I2C;
 	_device_id.devid_s.bus = bus;
 	_device_id.devid_s.address = address;
+
+    _mutex = PTHREAD_MUTEX_INITIALIZER;
 
 	PX4_INFO("*** I2C Device ID 0x%x %d", _device_id.devid, _device_id.devid);
 }

--- a/src/lib/drivers/device/qurt/I2C.hpp
+++ b/src/lib/drivers/device/qurt/I2C.hpp
@@ -127,7 +127,7 @@ private:
 	static _config_i2c_bus_func_t  _config_i2c_bus;
 	static _set_i2c_address_func_t _set_i2c_address;
 	static _i2c_transfer_func_t    _i2c_transfer;
-	static pthread_mutex_t         _mutex;
+	pthread_mutex_t                _mutex;
 };
 
 } // namespace device


### PR DESCRIPTION
This makes the QURT I2C driver use a mutex per I2C bus. 

Previously, if one I2C bus crashes or is hung it crashes all the other buses. For example the baro bus can get stalled if another bus gets stalled. 

Note: The timeout to recognize an I2C bus is being held for too long is still on the order of 6 seconds at times. Far too long for safety of others devices on the same bus. 