### PR TITLE
fix bmp388 build for voxl2

### DIFF
--- a/src/drivers/barometer/bmp388/bmp388.cpp
+++ b/src/drivers/barometer/bmp388/bmp388.cpp
@@ -308,6 +308,9 @@ BMP388::get_measurement_time()
 		case BMP3_OVERSAMPLING_8X:
 			meas_time_us = 22500;
 			break;
+
+		default: // handle unsupported / impossible cases to make compiler happy
+			break;
 		}
 
 	} else if (osr_t == BMP3_OVERSAMPLING_2X) {
@@ -318,6 +321,9 @@ BMP388::get_measurement_time()
 
 		case BMP3_OVERSAMPLING_32X:
 			meas_time_us = 68900;
+			break;
+
+		default: // handle unsupported / impossible cases to make compiler happy
 			break;
 		}
 	}


### PR DESCRIPTION
### Solved Problem
BMP388 driver did not build for voxl2 slpi with error:
```
/usr/local/workspace/px4-firmware/src/drivers/barometer/bmp388/bmp388.cpp:295:11: fatal error: no case matching constant switch condition '4'
                switch (osr_p) {
                        ^~~~~
1 error generated.
```

Added default switch case to handle impossible cases and make compiler happy