### PR TITLE
Circular expo for acro and altitude

### DIFF
--- a/src/lib/mathlib/math/Functions.hpp
+++ b/src/lib/mathlib/math/Functions.hpp
@@ -77,7 +77,7 @@ T sq(T val)
  * @param value [-1,1] input value to function
  * @param e [0,1] function parameter to set ratio between linear and cubic shape
  * 		0 - pure linear function
- * 		1 - pure cubic function
+ * 		1 - pure x^5 function
  * @return result of function output
  */
 template<typename T>
@@ -85,7 +85,7 @@ const T expo(const T &value, const T &e)
 {
 	T x = constrain(value, (T) - 1, (T) 1);
 	T ec = constrain(e, (T) 0, (T) 1);
-	return (1 - ec) * x + ec * x * x * x;
+	return (1 - ec) * x + ec * x * x * x * x * x;
 }
 
 /*

--- a/src/modules/flight_mode_manager/tasks/ManualAltitudeCommandVel/FlightTaskManualAltitudeCommandVel.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitudeCommandVel/FlightTaskManualAltitudeCommandVel.cpp
@@ -107,7 +107,7 @@ void FlightTaskManualAltitudeCommandVel::_updateSetpoints()
 	// thrust along xy is demanded. The maximum thrust along xy depends on the thrust
 	// setpoint along z-direction, which is computed in PositionControl.cpp.
 
-	Vector2f sp(_sticks.getPosition().slice<2, 1>(0, 0));
+	Vector2f sp = _sticks.getPitchRollExpo();
 
 	_man_input_filter.setParameters(_deltatime, _param_mc_man_tilt_tau.get());
 	_man_input_filter.update(sp);

--- a/src/modules/flight_mode_manager/tasks/Utility/Sticks.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/Sticks.cpp
@@ -62,6 +62,19 @@ bool Sticks::checkAndUpdateStickInputs()
 		_positions_expo(2) = math::expo_deadzone(_positions(2), _param_mpc_z_man_expo.get(),  _param_mpc_hold_dz.get());
 		_positions_expo(3) = math::expo_deadzone(_positions(3), _param_mpc_yaw_expo.get(),    _param_mpc_hold_dz.get());
 
+		// Pitch and Roll expo calculated on 2d vector length to maintain direction and provide circular consistency in magnitude. This is more correct and results in a nicer pilot feel.
+		_positions_pr_expo(0) = 0;
+		_positions_pr_expo(1) = 0;
+		Vector2f pr_stick{_positions(0), _positions(1)};
+		float pr_stick_len = pr_stick.length();
+		if (pr_stick_len > 1.0f) {
+			pr_stick.normalize();
+			pr_stick_len = 1.0f;
+		}
+		if (pr_stick_len > FLT_EPSILON) {
+			// Apply expo to magnitude of roll and pitch as a 2d vector for correct direction and scale around the circle
+			_positions_pr_expo = pr_stick.unit() * math::expo_deadzone(pr_stick_len, _param_mpc_xy_man_expo.get(), _param_mpc_hold_dz.get());
+		}
 		// valid stick inputs are required
 		_input_available = manual_control_setpoint.valid && _positions.isAllFinite();
 

--- a/src/modules/flight_mode_manager/tasks/Utility/Sticks.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/Sticks.hpp
@@ -72,7 +72,16 @@ public:
 	float getThrottleZeroCentered() const { return -_positions(2); } // Convert Z-axis(down) command to Up-axis frame
 	float getThrottleZeroCenteredExpo() const { return -_positions_expo(2); }
 	const matrix::Vector2f getPitchRoll() { return _positions.slice<2, 1>(0, 0); }
-	const matrix::Vector2f getPitchRollExpo() { return _positions_expo.slice<2, 1>(0, 0); }
+
+	/**
+	 * @brief Get Pitch and Roll expo calculated on 2d vector length to maintain direction
+	 *  and provide circular consistency in magnitude. This is more correct and results in
+	 *  a nicer pilot feel than applying the exponential function to the pitch and roll
+	 *  vector components independently.
+	 *
+	 * @return const matrix::Vector2f
+	 */
+	const matrix::Vector2f getPitchRollExpo() { return _positions_pr_expo; }
 
 	/**
 	 * Limit the the horizontal input from a square shaped joystick gimbal to a unit circle
@@ -92,6 +101,7 @@ private:
 	bool _input_available{false};
 	matrix::Vector4f _positions; ///< unmodified manual stick inputs
 	matrix::Vector4f _positions_expo; ///< modified manual sticks using expo function
+	matrix::Vector2f _positions_pr_expo; ///< only pitch and roll as 2D vector using expo function
 
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
 	uORB::Subscription _failsafe_flags_sub{ORB_ID(failsafe_flags)};

--- a/src/modules/mc_rate_control/MulticopterRateControl.cpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.cpp
@@ -188,9 +188,20 @@ MulticopterRateControl::Run()
 
 			if (_manual_control_setpoint_sub.update(&manual_control_setpoint)) {
 				// manual rates control - ACRO mode
+				Vector2f rp_sp{0, 0};
+				Vector2f rp_stick{manual_control_setpoint.roll, -manual_control_setpoint.pitch};
+				float rp_stick_len = rp_stick.length();
+				if (rp_stick_len > 1.0f) {
+					rp_stick.normalize();
+					rp_stick_len = 1.0f;
+				}
+				if (rp_stick_len > FLT_EPSILON) {
+					// Apply expo to magnitude of roll and pitch as a 2d vector for correct direction and scale around the circle
+					rp_sp = rp_stick.unit() * math::superexpo(rp_stick_len, _param_mc_acro_expo.get(), _param_mc_acro_supexpo.get());
+				}
 				const Vector3f man_rate_sp{
-					math::superexpo(manual_control_setpoint.roll, _param_mc_acro_expo.get(), _param_mc_acro_supexpo.get()),
-					math::superexpo(-manual_control_setpoint.pitch, _param_mc_acro_expo.get(), _param_mc_acro_supexpo.get()),
+					rp_sp(0),
+					rp_sp(1),
 					math::superexpo(manual_control_setpoint.yaw, _param_mc_acro_expo_y.get(), _param_mc_acro_supexpoy.get())};
 
 				_rates_setpoint = man_rate_sp.emult(_acro_rate_max);
@@ -296,7 +307,7 @@ MulticopterRateControl::Run()
 						const float time_start = 5.0f;
 						float time_since_start = (float)(hrt_absolute_time() - _takeoff_time) / 1.e6f - time_start;
 
-						if (time_since_start > 0) {							
+						if (time_since_start > 0) {
 							int freq_idx = floor(time_since_start / (_param_mc_inject_sine_t.get() + _param_mc_inject_rest_t.get()));
 
 							if (freq_idx < _param_mc_inject_cnt.get()) {


### PR DESCRIPTION
Fix expo function to maintain vector angle & correct magnitude in circular geometry (instead of calculating components in cartesian). This prevents extreme control inputs in the corners, and gives the pilot a round input space which makes sense. Make expo not leaner + ^3 but rather linear + ^5 which should make center stick much more linear.
