### PR TITLE
Added new expo x5 stick feel for acro and custom FPV altitude hold mode

### DIFF
--- a/src/lib/mathlib/math/Functions.hpp
+++ b/src/lib/mathlib/math/Functions.hpp
@@ -88,6 +88,14 @@ const T expo(const T &value, const T &e)
 	return (1 - ec) * x + ec * x * x * x;
 }
 
+template<typename T>
+const T expo_x5(const T &value, const T &e)
+{
+	T x = constrain(value, (T) - 1, (T) 1);
+	T ec = constrain(e, (T) 0, (T) 1);
+	return (1 - ec) * x + ec * x * x * x * x * x;
+}
+
 /*
  * So called SuperExpo function implementation.
  * It is a 1/(1-x) function to further shape the rc input curve intuitively.
@@ -105,6 +113,14 @@ const T superexpo(const T &value, const T &e, const T &g)
 	T x = constrain(value, (T) - 1, (T) 1);
 	T gc = constrain(g, (T) 0, (T) 0.99);
 	return expo(x, e) * (1 - gc) / (1 - fabsf(x) * gc);
+}
+
+template<typename T>
+const T superexpo_x5(const T &value, const T &e, const T &g)
+{
+	T x = constrain(value, (T) - 1, (T) 1);
+	T gc = constrain(g, (T) 0, (T) 0.99);
+	return expo_x5(x, e) * (1 - gc) / (1 - fabsf(x) * gc);
 }
 
 /*
@@ -138,6 +154,11 @@ const T expo_deadzone(const T &value, const T &e, const T &dz)
 	return expo(deadzone(value, dz), e);
 }
 
+template<typename T>
+const T expo_x5_deadzone(const T &value, const T &e, const T &dz)
+{
+	return expo_x5(deadzone(value, dz), e);
+}
 
 /*
  * Constant, linear, constant function with the two corner points as parameters

--- a/src/modules/flight_mode_manager/tasks/ManualAltitudeCommandVel/FlightTaskManualAltitudeCommandVel.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitudeCommandVel/FlightTaskManualAltitudeCommandVel.cpp
@@ -107,7 +107,7 @@ void FlightTaskManualAltitudeCommandVel::_updateSetpoints()
 	// thrust along xy is demanded. The maximum thrust along xy depends on the thrust
 	// setpoint along z-direction, which is computed in PositionControl.cpp.
 
-	Vector2f sp(_sticks.getPosition().slice<2, 1>(0, 0));
+	Vector2f sp = _sticks.getPitchRollExpo();
 
 	_man_input_filter.setParameters(_deltatime, _param_mc_man_tilt_tau.get());
 	_man_input_filter.update(sp);

--- a/src/modules/flight_mode_manager/tasks/Utility/Sticks.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/Sticks.cpp
@@ -62,6 +62,24 @@ bool Sticks::checkAndUpdateStickInputs()
 		_positions_expo(2) = math::expo_deadzone(_positions(2), _param_mpc_z_man_expo.get(),  _param_mpc_hold_dz.get());
 		_positions_expo(3) = math::expo_deadzone(_positions(3), _param_mpc_yaw_expo.get(),    _param_mpc_hold_dz.get());
 
+		// Pitch and Roll expo calculated on 2d vector length to maintain direction and provide circular consistency in magnitude. This is more correct and results in a nicer pilot feel.
+		_positions_pr_expo(0) = 0;
+		_positions_pr_expo(1) = 0;
+		Vector2f pr_stick{_positions(0), _positions(1)};
+		float pr_stick_len = pr_stick.length();
+		if (pr_stick_len > 1.0f) {
+			pr_stick.normalize();
+			pr_stick_len = 1.0f;
+		}
+		if (pr_stick_len > FLT_EPSILON) {
+			// Apply expo to magnitude of roll and pitch as a 2d vector for correct direction and scale around the circle
+			if (_param_mc_expo_x5.get()) {
+				_positions_pr_expo = pr_stick.unit() * math::expo_x5_deadzone(pr_stick_len, _param_mpc_xy_man_expo.get(), _param_mpc_hold_dz.get());
+			} else {
+				_positions_pr_expo = pr_stick.unit() * math::expo_deadzone(pr_stick_len, _param_mpc_xy_man_expo.get(), _param_mpc_hold_dz.get());
+			}
+		}
+
 		// valid stick inputs are required
 		_input_available = manual_control_setpoint.valid && _positions.isAllFinite();
 

--- a/src/modules/flight_mode_manager/tasks/Utility/Sticks.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/Sticks.hpp
@@ -72,7 +72,7 @@ public:
 	float getThrottleZeroCentered() const { return -_positions(2); } // Convert Z-axis(down) command to Up-axis frame
 	float getThrottleZeroCenteredExpo() const { return -_positions_expo(2); }
 	const matrix::Vector2f getPitchRoll() { return _positions.slice<2, 1>(0, 0); }
-	const matrix::Vector2f getPitchRollExpo() { return _positions_expo.slice<2, 1>(0, 0); }
+	const matrix::Vector2f getPitchRollExpo() { return _positions_pr_expo; }
 
 	/**
 	 * Limit the the horizontal input from a square shaped joystick gimbal to a unit circle
@@ -92,11 +92,13 @@ private:
 	bool _input_available{false};
 	matrix::Vector4f _positions; ///< unmodified manual stick inputs
 	matrix::Vector4f _positions_expo; ///< modified manual sticks using expo function
+	matrix::Vector2f _positions_pr_expo; ///< only pitch and roll as 2D vector using expo function
 
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
 	uORB::Subscription _failsafe_flags_sub{ORB_ID(failsafe_flags)};
 
 	DEFINE_PARAMETERS(
+		(ParamInt<px4::params::MC_EXPO_X5>) _param_mc_expo_x5,
 		(ParamFloat<px4::params::MPC_HOLD_DZ>) _param_mpc_hold_dz,
 		(ParamFloat<px4::params::MPC_XY_MAN_EXPO>) _param_mpc_xy_man_expo,
 		(ParamFloat<px4::params::MPC_Z_MAN_EXPO>) _param_mpc_z_man_expo,

--- a/src/modules/mc_rate_control/MulticopterRateControl.hpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.hpp
@@ -170,6 +170,7 @@ private:
 		(ParamFloat<px4::params::MC_ACRO_R_MAX>) _param_mc_acro_r_max,
 		(ParamFloat<px4::params::MC_ACRO_P_MAX>) _param_mc_acro_p_max,
 		(ParamFloat<px4::params::MC_ACRO_Y_MAX>) _param_mc_acro_y_max,
+		(ParamInt<px4::params::MC_EXPO_X5>) _param_mc_expo_x5,
 		(ParamFloat<px4::params::MC_ACRO_EXPO>) _param_mc_acro_expo,			/**< expo stick curve shape (roll & pitch) */
 		(ParamFloat<px4::params::MC_ACRO_EXPO_Y>) _param_mc_acro_expo_y,				/**< expo stick curve shape (yaw) */
 		(ParamFloat<px4::params::MC_ACRO_SUPEXPO>) _param_mc_acro_supexpo,		/**< superexpo stick curve shape (roll & pitch) */

--- a/src/modules/mc_rate_control/mc_rate_control_params.c
+++ b/src/modules/mc_rate_control/mc_rate_control_params.c
@@ -348,6 +348,15 @@ PARAM_DEFINE_FLOAT(MC_ACRO_P_MAX, 720.0f);
 PARAM_DEFINE_FLOAT(MC_ACRO_Y_MAX, 540.0f);
 
 /**
+ * Select x5 Expo in Acro and Other Flight Modes
+ *
+ * @value 0 Standard expo
+ * @value 1 x5 expo
+ * @group Multicopter Rate Control
+ */
+PARAM_DEFINE_INT32(MC_EXPO_X5, 1);
+
+/**
  * Acro mode Expo factor for Roll and Pitch.
  *
  * Exponential factor for tuning the input curve shape.


### PR DESCRIPTION
For acro mode there is a new parameter MC_ACRO_EXPO_X5 that is set to 1 by default. This will use new expo x5 in acro mode but can be disabled to go back to original if desired. The expo x5 is also used now in custom FPV altitude hold mode regardless of parameter settings. Other altitude hold mode variations remain the same.