### PR TITLE
zerorf yaw fix fpv

### DIFF
--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -854,7 +854,7 @@ void Ekf::updateHorizontalDeadReckoningstatus()
 
 	if (!_horizontal_deadreckon_time_exceeded && deadreckon_time_exceeded) {
 		// deadreckon time now exceeded
-		ECL_WARN("dead reckon time exceeded");
+		PX4_WARN("dead reckon time exceeded");
 	}
 
 	_horizontal_deadreckon_time_exceeded = deadreckon_time_exceeded;
@@ -1122,6 +1122,9 @@ void Ekf::loadMagCovData()
 
 void Ekf::resetQuatStateYaw(float yaw, float yaw_variance)
 {
+
+	PX4_INFO("resetQuatStateYaw called: %f (%f)\n", (double)yaw, (double)yaw_variance);
+
 	// save a copy of the quaternion state for later use in calculating the amount of reset change
 	const Quatf quat_before_reset = _state.quat_nominal;
 

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -854,7 +854,7 @@ void Ekf::updateHorizontalDeadReckoningstatus()
 
 	if (!_horizontal_deadreckon_time_exceeded && deadreckon_time_exceeded) {
 		// deadreckon time now exceeded
-		PX4_WARN("dead reckon time exceeded");
+		ECL_WARN("dead reckon time exceeded");
 	}
 
 	_horizontal_deadreckon_time_exceeded = deadreckon_time_exceeded;

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -499,14 +499,22 @@ void EKF2::Run()
 						_instance, latitude, longitude, static_cast<double>(altitude));
 				}
 
-				PX4_WARN("Reset global YAW for new origin!");
-				// TODO fix EV yaw value as it becomes used as global not local.
-				if (vehicle_command.param4 <= FP_ZERO)
+				PX4_WARN("Reset global YAW for new origin to %f", (double)vehicle_command.param4);
+				// TODO fix EV yaw value as it becomes used as global not local
+
+				static int32_t has_mag = -1;
+				if (has_mag < 0)
+					param_get(param_find("SYS_HAS_MAG"), &has_mag);
+
+				if (!has_mag || vehicle_command.param4 <= FP_ZERO)
 				{
-					PX4_WARN("Attempting to reset EKF global Yaw rotation to %f", (double)vehicle_command.param4);
 					_ekf.avg_mag_heading = vehicle_command.param4;   // TODO make get/setter for this attribute
+					PX4_WARN("Explicit attempting to reset EKF global Yaw rotation to %f / %f", (double)vehicle_command.param4, (double)_ekf.avg_mag_heading);
 					_ekf.forceResetQuatStateYaw();
-	//				 TODO fix EV yaw value as it becomes used as global not local.
+					_ekf.has_ev_heading_ned = true;
+
+					if (_ekf.enable_NED_convert(true))
+						_preflt_checker.reset();
 				}
 
 			}
@@ -1462,6 +1470,7 @@ void EKF2::PublishLocalPosition(const hrt_abstime &timestamp)
 	lpos.az = vel_deriv(2);
 
 	lpos.xy_valid = _ekf.local_position_is_valid();
+        PX4_WARN("lpos.xy_valid = _ekf.local_position_is_valid %d\n", lpos.xy_valid);
 	lpos.v_xy_valid = _ekf.local_position_is_valid();
 
 	// TODO: some modules (e.g.: mc_pos_control) don't handle v_z_valid != z_valid properly

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -1400,7 +1400,6 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 
 		case MAV_CMD_NAV_TAKEOFF:
 		{
-
 			mission_item->nav_cmd = NAV_CMD_TAKEOFF;
 			mission_item->yaw = wrap_2pi(math::radians(mavlink_mission_item->param4));
 
@@ -1408,7 +1407,6 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 			{
 				mission_item->yaw = 0;
 			}
-
 
 			// TODO may want to just have a new PX4 param to globally rule them all on this feature vs
 			// looking at has nag and ev_ctrl

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -1400,8 +1400,15 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 
 		case MAV_CMD_NAV_TAKEOFF:
 		{
+
 			mission_item->nav_cmd = NAV_CMD_TAKEOFF;
 			mission_item->yaw = wrap_2pi(math::radians(mavlink_mission_item->param4));
+
+			if (std::isnan(mavlink_mission_item->param4))
+			{
+				mission_item->yaw = 0;
+			}
+
 
 			// TODO may want to just have a new PX4 param to globally rule them all on this feature vs
 			// looking at has nag and ev_ctrl


### PR DESCRIPTION
### Solved Problem
When Mag = 0, all zerorf mission run against true north instead of user provide heading in mission request.

### Changelog Entry

### Alternatives

### Test coverage
Test flown on D0013

### Context
