### PR TITLE
update to dds to expose battery status as ros2 endpoint from dds

### DIFF
--- a/src/modules/microdds_client/dds_topics.yaml
+++ b/src/modules/microdds_client/dds_topics.yaml
@@ -23,6 +23,9 @@ publications:
   # - topic: /fmu/out/vehicle_angular_velocity
   #   type: px4_msgs::msg::VehicleAngularVelocity
 
+  - topic: /fmu/out/battery_status
+    type: px4_msgs::msg::BatteryStatus
+
   - topic: /fmu/out/vehicle_attitude
     type: px4_msgs::msg::VehicleAttitude
 


### PR DESCRIPTION
### Solved Problem
Battery status was requested by customer to be exposed in ROS2 

### Solution
Added battery status to the YAML for the microdds

