### PR TITLE
detect modal elrs reboots

### DIFF
--- a/src/drivers/rc/crsf_rc/CrsfParser.cpp
+++ b/src/drivers/rc/crsf_rc/CrsfParser.cpp
@@ -122,11 +122,14 @@ typedef struct {
 
 static bool ProcessChannelData(const uint8_t *data, const uint32_t size, CrsfPacket_t *const new_packet);
 static bool ProcessLinkStatistics(const uint8_t *data, const uint32_t size, CrsfPacket_t *const new_packet);
+static bool ProcessDeviceInfo(const uint8_t *data, const uint32_t size, CrsfPacket_t *const new_packet);
 
-#define CRSF_PACKET_DESCRIPTOR_COUNT  2
+// packet_size of 0 means variable-length (size validation skipped, actual size used for payload read)
+#define CRSF_PACKET_DESCRIPTOR_COUNT  3
 static const CrsfPacketDescriptor_t crsf_packet_descriptors[CRSF_PACKET_DESCRIPTOR_COUNT] = {
 	{CRSF_PACKET_TYPE_RC_CHANNELS_PACKED, CRSF_PAYLOAD_SIZE_RC_CHANNELS, ProcessChannelData},
 	{CRSF_PACKET_TYPE_LINK_STATISTICS, CRSF_PAYLOAD_SIZE_LINK_STATISTICS, ProcessLinkStatistics},
+	{CRSF_PACKET_TYPE_DEVICE_INFO, 0, ProcessDeviceInfo},
 };
 
 static enum PARSER_STATE parser_state = PARSER_STATE_HEADER;
@@ -226,6 +229,15 @@ static bool ProcessLinkStatistics(const uint8_t *data, const uint32_t size, Crsf
 	return true;
 }
 
+// Device Info payload: [dest][src][device_name\0][serial 4B][hwVer 4B][swVer 4B][fieldCnt][parameterVersion]
+// parameterVersion is the last byte of the payload; bit 7 set means first boot after reset.
+static bool ProcessDeviceInfo(const uint8_t *data, const uint32_t size, CrsfPacket_t *const new_packet)
+{
+	new_packet->message_type = CRSF_MESSAGE_TYPE_DEVICE_INFO;
+	new_packet->device_info.parameter_version = (size >= 1) ? data[size - 1] : 0;
+	return true;
+}
+
 static CrsfPacketDescriptor_t *FindCrsfDescriptor(const enum CRSF_PACKET_TYPE packet_type)
 {
 	uint32_t i;
@@ -291,8 +303,9 @@ bool CrsfParser_TryParseCrsfPacket(CrsfPacket_t *const new_packet, CrsfParserSta
 
 			// If we know what this packet is...
 			if (working_descriptor != NULL) {
-				// Validate length
-				if (packet_size != working_descriptor->packet_size + PACKET_SIZE_TYPE_SIZE) {
+				// Validate length (packet_size == 0 means variable-length, skip validation)
+				if (working_descriptor->packet_size != 0
+				    && packet_size != working_descriptor->packet_size + PACKET_SIZE_TYPE_SIZE) {
 					parser_statistics->invalid_known_packet_sizes++;
 					parser_state = PARSER_STATE_HEADER;
 					working_segment_size = HEADER_SIZE;
@@ -301,7 +314,12 @@ bool CrsfParser_TryParseCrsfPacket(CrsfPacket_t *const new_packet, CrsfParserSta
 					continue;
 				}
 
-				working_segment_size = working_descriptor->packet_size;
+				// For variable-length packets, derive payload size from the packet's size field
+				if (working_descriptor->packet_size != 0) {
+					working_segment_size = working_descriptor->packet_size;
+				} else {
+					working_segment_size = packet_size - PACKET_TYPE_SIZE - CRC_SIZE;
+				}
 
 			} else {
 				// We don't know what this packet is, so we'll let the parser continue

--- a/src/drivers/rc/crsf_rc/CrsfParser.hpp
+++ b/src/drivers/rc/crsf_rc/CrsfParser.hpp
@@ -72,9 +72,14 @@ struct CrsfParserStatistics_t {
 	uint32_t invalid_unknown_packet_sizes;
 };
 
+struct CrsfDeviceInfo_t {
+	uint8_t parameter_version;
+};
+
 enum CRSF_MESSAGE_TYPE {
 	CRSF_MESSAGE_TYPE_RC_CHANNELS,
 	CRSF_MESSAGE_TYPE_LINK_STATISTICS,
+	CRSF_MESSAGE_TYPE_DEVICE_INFO,
 };
 
 typedef struct {
@@ -83,6 +88,7 @@ typedef struct {
 	union {
 		CrsfChannelData_t channel_data;
 		CrsfLinkStatistics_t link_statistics;
+		CrsfDeviceInfo_t device_info;
 	};
 
 	// Raw frame data for libmodal-pipe publishing

--- a/src/drivers/rc/crsf_rc/CrsfRc.cpp
+++ b/src/drivers/rc/crsf_rc/CrsfRc.cpp
@@ -251,7 +251,19 @@ void CrsfRc::Run()
 				_input_rc.link_quality = new_crsf_packet.link_statistics.uplink_link_quality;
 				break;
 
+			case CRSF_MESSAGE_TYPE_DEVICE_INFO:
+				// ELRS sets bit 7 of parameterVersion only on the first Device Info after a reset
+				if (new_crsf_packet.device_info.parameter_version & 0x80) {
+					new_crsf_packet.raw_frame[new_crsf_packet.raw_frame_len - 1] = '\0';
+					PX4_WARN("ELRS receiver rebooted: %s",
+						 (char *)(new_crsf_packet.raw_frame + 5));
+				}
+				break;
+
 			default:
+				PX4_INFO("unknown packet: type=0x%02x, len=%u",
+					new_crsf_packet.raw_frame_len > 2 ? new_crsf_packet.raw_frame[2] : 0,
+					new_crsf_packet.raw_frame_len);
 				break;
 			}
 		}


### PR DESCRIPTION
Allows identifying when the receiver reboots to help identify if the ELRS receiver has rebooted which sometimes causes an unknown crc error. This will work on our next ELRS version after this commit: https://github.com/modalai/ExpressLRS/commit/41df885572a16572070882a1f7a29909f71f5c51