### PR TITLE
add the teseo GPS logic to the M0197 platform

### DIFF
--- a/boards/modalai/voxl2/target/voxl-px4-start
+++ b/boards/modalai/voxl2/target/voxl-px4-start
@@ -150,7 +150,14 @@ qshell iis2mdc start -R 10 -X -b 1
 # GPS
 if [ "$GPS" != "NONE" ]; then
     if [ "$PLATFORM" == "M0197" ]; then
-	gps start -d /dev/ttyHS7
+	# BMM150 = Teseo GPS board, no BMM150 = ublox
+	if [ "$BMM150_DETECTED" == "1" ]; then
+	    /bin/echo "Starting GPS with Teseo driver on M0197"
+	    gps start -d /dev/ttyHS7 -p teseo
+	else
+	    /bin/echo "Starting GPS with UBX protocol (ublox) on M0197"
+	    gps start -d /dev/ttyHS7 -p ubx
+	fi
     else
 	# BMM150 = Teseo GPS board, no BMM150 = ublox
 	if [ "$BMM150_DETECTED" == "1" ]; then

--- a/boards/modalai/voxl2/target/voxl-px4-start
+++ b/boards/modalai/voxl2/target/voxl-px4-start
@@ -150,13 +150,12 @@ qshell iis2mdc start -R 10 -X -b 1
 # GPS
 if [ "$GPS" != "NONE" ]; then
     if [ "$PLATFORM" == "M0197" ]; then
-	# BMM150 = Teseo GPS board, no BMM150 = ublox
+	# BMM150 = Teseo GPS board, no BMM150 = default (ublox)
 	if [ "$BMM150_DETECTED" == "1" ]; then
 	    /bin/echo "Starting GPS with Teseo driver on M0197"
 	    gps start -d /dev/ttyHS7 -p teseo
 	else
-	    /bin/echo "Starting GPS with UBX protocol (ublox) on M0197"
-	    gps start -d /dev/ttyHS7 -p ubx
+	    gps start -d /dev/ttyHS7
 	fi
     else
 	# BMM150 = Teseo GPS board, no BMM150 = ublox


### PR DESCRIPTION
Added the BMM150 detection logic to start the Teseo GPS driver to the M0197 Platform. 