### PR TITLE
Mag arm check and recovery, DPS baro temp cal usage

### DIFF
--- a/boards/modalai/voxl2/target/voxl-px4-start
+++ b/boards/modalai/voxl2/target/voxl-px4-start
@@ -89,11 +89,13 @@ fi
 
 # First try to start external barometer on DSP
 EXTERNAL_BAROMETER=0
+DPS_BARO_DETECTED=0
 
 /bin/echo "Looking for external DPS368 barometer on DSP"
 if qshell dps310 start -X -b 1; then
 	/bin/echo "Detected external DPS368 barometer on DSP"
 	EXTERNAL_BAROMETER=1
+	DPS_BARO_DETECTED=1
 fi
 
 # If no DSP barometer, look for external barometers connected to the apps proc
@@ -102,6 +104,7 @@ if (( EXTERNAL_BAROMETER == 0 )); then
 	if dps310 start -X -b /dev/i2c-0; then
 		/bin/echo "Detected external DPS368 barometer"
 		EXTERNAL_BAROMETER=1
+		DPS_BARO_DETECTED=1
 	fi
 fi
 
@@ -119,11 +122,18 @@ if (( EXTERNAL_BAROMETER == 0 )); then
     if [ "$PLATFORM" == "M0197" ]; then
        /bin/echo "Starting dps368 barometer on M0197"
        qshell dps310 start -I -b 5
+       DPS_BARO_DETECTED=1
     else
         # Start Invensense ICP 101xx barometer built on to VOXL 2
         qshell icp101xx start -I -b 5
     fi
     qshell temperature_compensation start
+fi
+
+# DPS368 is stable across temperature and does not require thermal compensation.
+# Disable baro thermal cal so the routine only runs on the IMU.
+if (( DPS_BARO_DETECTED == 1 )); then
+	param set TC_B_ENABLE 0
 fi
 
 # Auto detect the magnetometer. If devices

--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -596,20 +596,8 @@ void EstimatorChecks::checkEstimatorStatusFlags(const Context &context, Report &
 			_position_reliant_on_optical_flow = !gps && optical_flow && !vision_position;
 		}
 
-		// Check for a magnetometer fault and notify the user
-		if (estimator_status_flags.cs_mag_fault) {
-			/* EVENT
-			 * @description
-			 * Land and calibrate the compass.
-			 */
-			reporter.armingCheckFailure(NavModes::All, health_component_t::local_position_estimate,
-						    events::ID("check_estimator_mag_fault"),
-						    events::Log::Critical, "Stopping compass use");
-
-			if (reporter.mavlink_log_pub()) {
-				mavlink_log_critical(reporter.mavlink_log_pub(), "Compass needs calibration - Land now!\t");
-			}
-		}
+		// Mag fault no longer blocks arming. EKF falls back to GSF yaw when mag faults,
+		// and mag_control.cpp can auto-recover the fault once innovations are healthy again.
 
 		if (estimator_status_flags.cs_gps_yaw_fault) {
 			/* EVENT

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -736,6 +736,8 @@ private:
 	float _gps_velD_diff_filt{0.0f};	///< GPS filtered Down velocity (m/sec)
 	uint64_t _last_gps_fail_us{0};		///< last system time in usec that the GPS failed it's checks
 	uint64_t _last_gps_pass_us{0};		///< last system time in usec that the GPS passed it's checks
+	uint64_t _last_mag_fail_us{0};		///< last system time in usec that the mag innovation exceeded recovery threshold
+	uint64_t _last_mag_pass_us{0};		///< last system time in usec that the mag innovation was within recovery threshold
 	float _gps_error_norm{1.0f};		///< normalised gps error
 	uint32_t _min_gps_health_time_us{10000000}; ///< GPS is marked as healthy only after this amount of time
 	bool _gps_checks_passed{false};		///> true when all active GPS checks have passed

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -1186,6 +1186,11 @@ bool Ekf::resetYawToEKFGSF()
 		_control_status.flags.mag_fault = true;
 		_warning_events.flags.emergency_yaw_reset_mag_stopped = true;
 
+		// Prime mag recovery timestamps so the auto-recovery requires a fresh
+		// 5s window of healthy innovations before clearing the fault.
+		_last_mag_fail_us = _time_delayed_us;
+		_last_mag_pass_us = 0;
+
 	} else if (_control_status.flags.gps_yaw) {
 		_control_status.flags.gps_yaw_fault = true;
 		_warning_events.flags.emergency_yaw_reset_gps_yaw_stopped = true;

--- a/src/modules/ekf2/EKF/mag_control.cpp
+++ b/src/modules/ekf2/EKF/mag_control.cpp
@@ -143,6 +143,15 @@ void Ekf::controlMagFusion()
 			mag_observation.copyTo(_aid_src_mag.observation);
 			mag_innov.copyTo(_aid_src_mag.innovation);
 
+			// Record mag health timestamps so a stuck mag_fault can auto-recover once
+			// innovations return to a healthy range (mirrors the GPS pass/fail pattern).
+			static constexpr float mag_health_innov_threshold = 0.35f; // rad, ~20 deg
+			if (fabsf(_aid_src_mag_heading.innovation) < mag_health_innov_threshold) {
+				_last_mag_pass_us = _time_delayed_us;
+			} else {
+				_last_mag_fail_us = _time_delayed_us;
+			}
+
 		} else if (!isNewestSampleRecent(_time_last_mag_buffer_push, 2 * MAG_MAX_INTERVAL)) {
 			// No data anymore. Stop until it comes back.
 			stopMagFusion();
@@ -192,6 +201,14 @@ void Ekf::controlMagFusion()
 		}
 
 		return;
+	}
+
+	// Auto-clear mag_fault once innovations have been healthy for 5s straight, allowing
+	// fusion to resume after transient interference (e.g. high-thrust punch-out).
+	if (_control_status.flags.mag_fault
+	    && isTimedOut(_last_mag_fail_us, (uint64_t)5e6)
+	    && (_last_mag_pass_us > _last_mag_fail_us)) {
+		_control_status.flags.mag_fault = false;
 	}
 
 	if (_params.mag_fusion_type >= MagFuseType::NONE

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -339,6 +339,10 @@ void LoggedTopics::add_debug_topics()
 	add_topic("mag_worker_data");
 	add_topic("sensor_preflight_mag", 500);
 	add_topic("actuator_test", 500);
+
+	// High-rate mag logging for mag-comp diagnostics
+	add_topic_multi("sensor_mag", 0, 4);
+	add_optional_topic_multi("vehicle_magnetometer", 0, 4);
 }
 
 void LoggedTopics::add_estimator_replay_topics()


### PR DESCRIPTION
Removed the mag fault flag from the arm check. Added logic to clear the mag fault flag if the mag has recovered. Added logic to voxl-px4-start script to disable baro temp cal if the DPS baro is detected. Added mag at full rate to debug log topics. 