### PR TITLE
fix(mavlink): remove blocking dataman lock from geofence upload

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -538,14 +538,8 @@ MavlinkMissionManager::send()
 	}
 
 	/* check for timed-out operations */
-	if (_state == MAVLINK_WPM_STATE_GETLIST && (_time_last_sent > 0)
-	    && hrt_elapsed_time(&_time_last_sent) > MAVLINK_MISSION_RETRY_TIMEOUT_DEFAULT) {
-
-		// try to request item again after timeout
-		send_mission_request(_transfer_partner_sysid, _transfer_partner_compid, _transfer_seq);
-
-	} else if (_state != MAVLINK_WPM_STATE_IDLE && (_time_last_recv > 0)
-		   && hrt_elapsed_time(&_time_last_recv) > MAVLINK_MISSION_PROTOCOL_TIMEOUT_DEFAULT) {
+	if (_state != MAVLINK_WPM_STATE_IDLE && (_time_last_recv > 0)
+	    && hrt_elapsed_time(&_time_last_recv) > MAVLINK_MISSION_PROTOCOL_TIMEOUT_DEFAULT) {
 
 		_mavlink->send_statustext_critical("Operation timeout\t");
 		events::send(events::ID("mavlink_mission_op_timeout"), events::Log::Error,
@@ -557,6 +551,12 @@ MavlinkMissionManager::send()
 
 		// since we are giving up, reset this state also, so another request can be started.
 		_transfer_in_progress = false;
+
+	} else if (_state == MAVLINK_WPM_STATE_GETLIST && (_time_last_sent > 0)
+		   && hrt_elapsed_time(&_time_last_sent) > MAVLINK_MISSION_RETRY_TIMEOUT_DEFAULT) {
+
+		// try to request item again after timeout
+		send_mission_request(_transfer_partner_sysid, _transfer_partner_compid, _transfer_seq);
 
 	} else if (_state == MAVLINK_WPM_STATE_IDLE) {
 		// reset flags
@@ -956,21 +956,6 @@ MavlinkMissionManager::handle_mission_count(const mavlink_message_t *msg)
 						DM_KEY_WAYPOINTS_OFFBOARD_0);	// use inactive storage for transmission
 			_transfer_current_seq = -1;
 
-			if (_mission_type == MAV_MISSION_TYPE_FENCE) {
-				// We're about to write new geofence items, so take the lock. It will be released when
-				// switching back to idle
-				PX4_DEBUG("locking fence dataman items");
-
-				int ret = dm_lock(DM_KEY_FENCE_POINTS);
-
-				if (ret == 0) {
-					_geofence_locked = true;
-
-				} else {
-					PX4_ERR("locking failed (%i)", errno);
-				}
-			}
-
 		} else if (_state == MAVLINK_WPM_STATE_GETLIST) {
 			_time_last_recv = hrt_absolute_time();
 
@@ -1006,15 +991,6 @@ MavlinkMissionManager::handle_mission_count(const mavlink_message_t *msg)
 void
 MavlinkMissionManager::switch_to_idle_state()
 {
-	// when switching to idle, we *always* check if the lock was held and release it.
-	// This is to ensure we don't end up in a state where we forget to release it.
-	if (_geofence_locked) {
-		dm_unlock(DM_KEY_FENCE_POINTS);
-		_geofence_locked = false;
-
-		PX4_DEBUG("unlocking geofence");
-	}
-
 	_state = MAVLINK_WPM_STATE_IDLE;
 }
 

--- a/src/modules/mavlink/mavlink_mission.h
+++ b/src/modules/mavlink/mavlink_mission.h
@@ -132,7 +132,6 @@ private:
 
 	static uint16_t		_geofence_update_counter;
 	static uint16_t		_safepoint_update_counter;
-	bool			_geofence_locked{false};		///< if true, we currently hold the dm_lock for the geofence (transaction in progress)
 
 	MavlinkRateLimiter	_slow_rate_limiter{100 * 1000};		///< Rate limit sending of the current WP sequence to 10 Hz
 


### PR DESCRIPTION
  ## fix(mavlink): remove blocking dataman lock from geofence upload

  ### Summary
  Geofence uploads from QGroundControl to VOXL2 were failing — QGC reported the
  upload rejected after maximum retries. This fixes the root cause in the MAVLink
  mission protocol handler. Regular mission uploads were never affected.

  ### Root cause
  `MavlinkMissionManager::handle_mission_count()` took a **blocking**
  `dm_lock(DM_KEY_FENCE_POINTS)` on the MAVLink **receive thread** before sending
  the first `MISSION_REQUEST` for a `MAV_MISSION_TYPE_FENCE` transfer. On VOXL2 two
  MAVLink instances share the global dataman lock and the static
  `_transfer_in_progress` flag, so the receive thread could block for the entire
  duration of a (possibly stalled) fence transfer. QGC therefore never received a
  `MISSION_REQUEST` and gave up after max retries.

  Secondary bug: `send()` evaluated the GETLIST retry **before** the
  protocol-timeout abort, so a stalled transfer never reliably reset
  `_transfer_in_progress`.

  ### Changes
  - Remove the fence `dm_lock`/`dm_unlock` and the `_geofence_locked` member from
    `mavlink_mission` entirely, matching upstream PX4 (`55d8adb35b`).
  - Reorder the `send()` timeout checks so the protocol-timeout abort runs before
    the GETLIST retry (backport of upstream `edd44e21d6`).

  ### Testing — verified on VOXL2 (M0054) hardware
  Flashed this branch and uploaded a geofence (4-vertex inclusion polygon +
  inclusion circle) from QGC:
  - Upload completes successfully — no rejection / retry failure.
  - Persistent storage `/data/px4/dataman` contains the fence
    (`num_items = 5`, `update_counter = 11`): the polygon + the circle.
  - `px4-navigator status` after a fresh load reports
    `1 inclusion polygon, 1 inclusion circle` — fence loaded and consumed
    correctly.
  - Repeated uploads all committed (counter incremented each time).
