### PR TITLE
fix(mavlink): set mission_type on MISSION_ITEM(_INT) responses

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -1635,6 +1635,7 @@ MavlinkMissionManager::format_mavlink_mission_item(const struct mission_item_s *
 	mavlink_mission_item->frame = mission_item->frame;
 	mavlink_mission_item->command = mission_item->nav_cmd;
 	mavlink_mission_item->autocontinue = mission_item->autocontinue;
+	mavlink_mission_item->mission_type = _mission_type;
 
 	/* default mappings for generic commands */
 	if (mission_item->frame == MAV_FRAME_MISSION) {

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -83,6 +83,11 @@ MavlinkMissionManager::init_offboard_mission()
 	if (!_dataman_init) {
 		_dataman_init = true;
 
+		// Build-verification marker — printed once per voxl-px4 start.
+		// If you see this line in the boot log, the running binary includes
+		// the ascend/geofence-download/voxl-fpv-dev fix (commit 024c26242a+).
+		PX4_WARN("ASCEND BUILD MARKER: geofence-download fix active (mission_type on MISSION_ITEM responses)");
+
 		/* lock MISSION_STATE item */
 		int dm_lock_ret = dm_lock(DM_KEY_MISSION_STATE);
 

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -83,11 +83,6 @@ MavlinkMissionManager::init_offboard_mission()
 	if (!_dataman_init) {
 		_dataman_init = true;
 
-		// Build-verification marker — printed once per voxl-px4 start.
-		// If you see this line in the boot log, the running binary includes
-		// the ascend/geofence-download/voxl-fpv-dev fix (commit 024c26242a+).
-		PX4_WARN("ASCEND BUILD MARKER: geofence-download fix active (mission_type on MISSION_ITEM responses)");
-
 		/* lock MISSION_STATE item */
 		int dm_lock_ret = dm_lock(DM_KEY_MISSION_STATE);
 


### PR DESCRIPTION
When responding to MISSION_REQUEST(_INT) during a fence or rally download, send_mission_item() value-initialized the outgoing mavlink_mission_item(_int)_t struct and then set seq/target_system/target_component/current — but never set the mission_type extension field. So responses always carried mission_type=0 (MAV_MISSION_TYPE_MISSION), even for fence or rally items.

QGroundControl (correctly per MAVLink v2) discards MISSION_ITEM(_INT) responses whose mission_type does not match the in-flight transfer, and after max retries reports "GeoFence transfer failed. Error: Mission read failed, maximum retries exceeded." This appears every time QGC connects to a vehicle that has a persisted fence in /data/px4/dataman (which is the common case after any reboot), because QGC's startup-sync downloads the existing fence and trips on every item read. RALLY downloads are affected the same way. MISSION downloads happen to work because mission_type=0 matches.

Wire evidence from tcpdump on the voxl-mavlink-server↔px4 channel:
  REQUEST_INT  seq=0 mission_type=1   ← QGC asks for fence item
  ITEM_INT     seq=0 mission_type=0   ← px4 replies with wrong mission_type

Set mavlink_mission_item->mission_type from _mission_type in format_mavlink_mission_item(), matching upstream PX4's behavior. Every other outgoing mission message (send_mission_count, send_mission_ack, send_mission_request) already sets mission_type correctly; only the item path was missing it.