### PR TITLE
comment out DPS baro on bus 1 (gps mount baro)

### DIFF
--- a/boards/modalai/voxl2/target/voxl-px4-start
+++ b/boards/modalai/voxl2/target/voxl-px4-start
@@ -91,12 +91,14 @@ fi
 EXTERNAL_BAROMETER=0
 DPS_BARO_DETECTED=0
 
-/bin/echo "Looking for external DPS368 barometer on DSP"
-if qshell dps310 start -X -b 1; then
-	/bin/echo "Detected external DPS368 barometer on DSP"
-	EXTERNAL_BAROMETER=1
-	DPS_BARO_DETECTED=1
-fi
+# commenting this out. This DPS on bus 1 is located on the gps mount which creates a poor baro environment, uncomment to try
+
+#/bin/echo "Looking for external DPS368 barometer on DSP"
+#if qshell dps310 start -X -b 1; then
+#	/bin/echo "Detected external DPS368 barometer on DSP"
+#	EXTERNAL_BAROMETER=1
+#	DPS_BARO_DETECTED=1
+#fi
 
 # If no DSP barometer, look for external barometers connected to the apps proc
 if (( EXTERNAL_BAROMETER == 0 )); then


### PR DESCRIPTION
We have determined that the baro in the GPS mount is poorly effected by its environment. Removing the starting of that baro from the start script so it falls back to a better option. 
