### PR TITLE
adding optional throttle accel slew limit

### DIFF
--- a/src/modules/flight_mode_manager/tasks/ManualAltitudeCommandVel/FlightTaskManualAltitudeCommandVel.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitudeCommandVel/FlightTaskManualAltitudeCommandVel.cpp
@@ -69,6 +69,7 @@ bool FlightTaskManualAltitudeCommandVel::activate(const trajectory_setpoint_s &l
 	_last_position = _position;			// initialize loop to assume we're stable
 	_position_setpoint(2) = NAN;
 	_velocity_setpoint(2) = 0.f;
+	_vel_z_slew.setForcedValue(0.f);		// match the initial velocity setpoint; avoids seeding from a possibly-bad estimate
 	_setDefaultConstraints();
 
 	return ret;
@@ -81,7 +82,27 @@ void FlightTaskManualAltitudeCommandVel::_scaleSticks()
 	_yawspeed_setpoint = _applyYawspeedFilter(yawspeed_target);
 
 	// Use sticks input with deadzone and exponential curve for vertical velocity
-	_velocity_setpoint(2) = _param_flgt_vz_max.get() * _sticks.getPositionExpo()(2);
+	const float vz_target = _param_flgt_vz_max.get() * _sticks.getPositionExpo()(2);
+
+	// Optionally slew-rate limit the vertical velocity setpoint so that abrupt
+	// throttle stick movements don't produce a step in the setpoint (e.g. slamming
+	// the throttle down instantly cutting power). The applicable limit depends on
+	// the direction the setpoint is moving (NED: more negative = climbing harder).
+	// A limit of 0 disables the slew and passes the target through directly.
+	const float accel_limit = (vz_target < _vel_z_slew.getState())
+				  ? _param_flgt_acc_lim_up.get()
+				  : _param_flgt_acc_lim_dn.get();
+
+	if (accel_limit > FLT_EPSILON) {
+		_vel_z_slew.setSlewRate(accel_limit);
+		_velocity_setpoint(2) = _vel_z_slew.update(vz_target, _deltatime);
+
+	} else {
+		// Slew disabled for this direction: pass through but keep the state in sync
+		// so re-enabling (or a direction change) doesn't cause a jump.
+		_vel_z_slew.setForcedValue(vz_target);
+		_velocity_setpoint(2) = vz_target;
+	}
 }
 
 float FlightTaskManualAltitudeCommandVel::_applyYawspeedFilter(float yawspeed_target)

--- a/src/modules/flight_mode_manager/tasks/ManualAltitudeCommandVel/FlightTaskManualAltitudeCommandVel.hpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitudeCommandVel/FlightTaskManualAltitudeCommandVel.hpp
@@ -42,6 +42,7 @@
 #include "FlightTask.hpp"
 #include "Sticks.hpp"
 #include <lib/mathlib/math/filter/AlphaFilter.hpp>
+#include <lib/slew_rate/SlewRate.hpp>
 #include <uORB/Subscription.hpp>
 
 class FlightTaskManualAltitudeCommandVel : public FlightTask
@@ -71,7 +72,9 @@ protected:
 					(ParamFloat<px4::params::MPC_MAN_Y_TAU>) _param_mpc_man_y_tau,
 					(ParamFloat<px4::params::MPC_MAN_TILT_MAX>) _param_mpc_man_tilt_max, /**< maximum tilt allowed for manual flight */
 					(ParamFloat<px4::params::MC_MAN_TILT_TAU>) _param_mc_man_tilt_tau,
-					(ParamFloat<px4::params::FLGT_VZ_MAX>) _param_flgt_vz_max
+					(ParamFloat<px4::params::FLGT_VZ_MAX>) _param_flgt_vz_max,
+					(ParamFloat<px4::params::FLGT_ACC_LIM_UP>) _param_flgt_acc_lim_up, /**< slew limit on climb vel sp, 0=off */
+					(ParamFloat<px4::params::FLGT_ACC_LIM_DN>) _param_flgt_acc_lim_dn /**< slew limit on descent vel sp, 0=off */
 					)
 private:
 
@@ -88,4 +91,6 @@ private:
 	matrix::Vector3f _last_position; /**< last loop's vehicle position */
 
 	AlphaFilter<matrix::Vector2f> _man_input_filter;
+
+	SlewRate<float> _vel_z_slew; /**< slew-rate limiter for the vertical velocity setpoint */
 };

--- a/src/modules/flight_mode_manager/tasks/ManualAltitudeCommandVel/flight_task_manual_altitude_command_vel_params.c
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitudeCommandVel/flight_task_manual_altitude_command_vel_params.c
@@ -44,3 +44,37 @@
  * @group FlightTask
  */
 PARAM_DEFINE_FLOAT(FLGT_VZ_MAX, 1.0f);
+
+/**
+ * Vertical velocity setpoint slew limit (climb)
+ *
+ * Maximum rate of change (acceleration) applied to the commanded vertical
+ * velocity setpoint while climbing. This prevents abrupt throttle stick
+ * movements from producing a step in the velocity setpoint.
+ * Set to 0 to disable the slew limit.
+ *
+ * @unit m/s^2
+ * @min 0.0
+ * @max 100.0
+ * @increment 0.01
+ * @decimal 3
+ * @group FlightTask
+ */
+PARAM_DEFINE_FLOAT(FLGT_ACC_LIM_UP, 0.0f);
+
+/**
+ * Vertical velocity setpoint slew limit (descent)
+ *
+ * Maximum rate of change (acceleration) applied to the commanded vertical
+ * velocity setpoint while descending. This prevents slamming the throttle
+ * stick down from instantly cutting power to the motors.
+ * Set to 0 to disable the slew limit.
+ *
+ * @unit m/s^2
+ * @min 0.0
+ * @max 100.0
+ * @increment 0.01
+ * @decimal 3
+ * @group FlightTask
+ */
+PARAM_DEFINE_FLOAT(FLGT_ACC_LIM_DN, 0.0f);


### PR DESCRIPTION
prevents killing motors suddenly on hard throttle-down and limits motor saturation on hard throttle-up in velocity-based altitude control flight task.

