### PR TITLE
Paul mag fault detect no recovery

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -597,7 +597,7 @@ void EstimatorChecks::checkEstimatorStatusFlags(const Context &context, Report &
 		}
 
 		// Mag fault no longer blocks arming. EKF falls back to GSF yaw when mag faults,
-		// and mag_control.cpp can auto-recover the fault once innovations are healthy again.
+		// and the fault persists until reboot (no auto-recovery).
 
 		if (estimator_status_flags.cs_gps_yaw_fault) {
 			/* EVENT

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -736,8 +736,6 @@ private:
 	float _gps_velD_diff_filt{0.0f};	///< GPS filtered Down velocity (m/sec)
 	uint64_t _last_gps_fail_us{0};		///< last system time in usec that the GPS failed it's checks
 	uint64_t _last_gps_pass_us{0};		///< last system time in usec that the GPS passed it's checks
-	uint64_t _last_mag_fail_us{0};		///< last system time in usec that the mag innovation exceeded recovery threshold
-	uint64_t _last_mag_pass_us{0};		///< last system time in usec that the mag innovation was within recovery threshold
 	float _gps_error_norm{1.0f};		///< normalised gps error
 	uint32_t _min_gps_health_time_us{10000000}; ///< GPS is marked as healthy only after this amount of time
 	bool _gps_checks_passed{false};		///> true when all active GPS checks have passed

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -1186,11 +1186,6 @@ bool Ekf::resetYawToEKFGSF()
 		_control_status.flags.mag_fault = true;
 		_warning_events.flags.emergency_yaw_reset_mag_stopped = true;
 
-		// Prime mag recovery timestamps so the auto-recovery requires a fresh
-		// 5s window of healthy innovations before clearing the fault.
-		_last_mag_fail_us = _time_delayed_us;
-		_last_mag_pass_us = 0;
-
 	} else if (_control_status.flags.gps_yaw) {
 		_control_status.flags.gps_yaw_fault = true;
 		_warning_events.flags.emergency_yaw_reset_gps_yaw_stopped = true;

--- a/src/modules/ekf2/EKF/mag_control.cpp
+++ b/src/modules/ekf2/EKF/mag_control.cpp
@@ -143,15 +143,6 @@ void Ekf::controlMagFusion()
 			mag_observation.copyTo(_aid_src_mag.observation);
 			mag_innov.copyTo(_aid_src_mag.innovation);
 
-			// Record mag health timestamps so a stuck mag_fault can auto-recover once
-			// innovations return to a healthy range (mirrors the GPS pass/fail pattern).
-			static constexpr float mag_health_innov_threshold = 0.35f; // rad, ~20 deg
-			if (fabsf(_aid_src_mag_heading.innovation) < mag_health_innov_threshold) {
-				_last_mag_pass_us = _time_delayed_us;
-			} else {
-				_last_mag_fail_us = _time_delayed_us;
-			}
-
 		} else if (!isNewestSampleRecent(_time_last_mag_buffer_push, 2 * MAG_MAX_INTERVAL)) {
 			// No data anymore. Stop until it comes back.
 			stopMagFusion();
@@ -201,14 +192,6 @@ void Ekf::controlMagFusion()
 		}
 
 		return;
-	}
-
-	// Auto-clear mag_fault once innovations have been healthy for 5s straight, allowing
-	// fusion to resume after transient interference (e.g. high-thrust punch-out).
-	if (_control_status.flags.mag_fault
-	    && isTimedOut(_last_mag_fail_us, (uint64_t)5e6)
-	    && (_last_mag_pass_us > _last_mag_fail_us)) {
-		_control_status.flags.mag_fault = false;
 	}
 
 	if (_params.mag_fusion_type >= MagFuseType::NONE


### PR DESCRIPTION
Reverted old commit to remove the mag recovery change for now, if the mag faults it will stay faulted until a reboot. Did not remove the arm fix though. Also added the ability for the mag fault to trigger without the gps vel requirement to be met, since it often does not trigger when it should due to that check. 