### PR TITLE
PWM Range assignment for GPIO control within voxl-esc driver

### DIFF
--- a/src/drivers/actuators/voxl_esc/voxl_esc.cpp
+++ b/src/drivers/actuators/voxl_esc/voxl_esc.cpp
@@ -307,7 +307,11 @@ int VoxlEsc::load_params(voxl_esc_params_t *params, ch_assign_t *map)
 	param_get(param_find("VOXL_ESC_T_WARN"), &params->esc_warn_temp_threshold);
 	param_get(param_find("VOXL_ESC_T_OVER"), &params->esc_over_temp_threshold);
 
-	param_get(param_find("GPIO_CTL_CH"), &params->gpio_ctl_channel);
+	//param_get(param_find("GPIO_CTL_CH"), &params->gpio_ctl_channel);
+
+	param_get(param_find("VOXL_ESC_GPIO_RC"), &params->gpio_rc_channel);
+	param_get(param_find("VOXL_ESC_GPIO_MN"), &params->gpio_pwm_min);
+	param_get(param_find("VOXL_ESC_GPIO_MX"), &params->gpio_pwm_max);
 
 	param_get(param_find("VOXL_ESC_CMD"), &params->cmd_type);
 
@@ -357,10 +361,25 @@ int VoxlEsc::load_params(voxl_esc_params_t *params, ch_assign_t *map)
 		ret = PX4_ERROR;
 	}
 
+	/*
 	if (params->gpio_ctl_channel < 0 || params->gpio_ctl_channel > 6) {
 		PX4_ERR("Invalid parameter GPIO_CTL_CH.  Please verify parameters.");
 		params->gpio_ctl_channel = 0;
 		ret = PX4_ERROR;
+	}
+	*/
+
+	const bool rc_set 	= (params->gpio_rc_channel >= 1 && params->gpio_rc_channel <= 16);
+	const bool pmin_set	= (params->gpio_pwm_min >= 900 && params->gpio_pwm_min <= 2100);
+	const bool pmax_set	= (params->gpio_pwm_max >= 900 && params->gpio_pwm_max <= 2100);
+	const bool gpio_ctl_valid = (rc_set && pmin_set && pmax_set);
+
+	if (!gpio_ctl_valid) {
+		PX4_ERR("Invalid GPIO control parameters. To enable GPIO control, set GPIO_RC_CHANNEL to a valid RC channel (1-16) and set GPIO_PWM_MIN/MAX to valid PWM values (900-2100).  Please verify parameters.");
+		params->gpio_rc_channel = -1;
+	} else if (params->gpio_pwm_max - params->gpio_pwm_min < 2 * VOXL_ESC_GPIO_HSYT_US) {
+		PX4_ERR("Invalid GPIO PWM range. The difference between GPIO_PWM_MAX and GPIO_PWM_MIN must be at least %d us to account for hysteresis.  Please verify parameters.", 2 * VOXL_ESC_GPIO_HSYT_US);
+		params->gpio_rc_channel = -1;
 	}
 
 	for (int i = 0; i < VOXL_ESC_OUTPUT_CHANNELS; i++) {
@@ -1547,6 +1566,7 @@ void VoxlEsc::Run()
 		}
 
 		// check if gpio control is enabled
+		/*
 		if (_parameters.gpio_ctl_channel > 0) {
 
 			_gpio_ctl_en = true;
@@ -1580,6 +1600,39 @@ void VoxlEsc::Run()
 			}
 
 		}
+		*/
+
+		if (_parameters.gpio_rc_channel > 0) {
+			_gpio_ctl_en = true;
+
+			input_rc_s rc;
+			const bool have_rc = _input_rc_sub.copy(&rc);
+
+			if (have_rc
+				&& !rc.rc_lost
+				&& rc.channel_count >= _parameters.gpio_rc_channel) {
+				
+				const uint16_t pwm = rc.values[_parameters.gpio_rc_channel - 1];
+				const int32_t low = _parameters.gpio_pwm_min;
+				const int32_t high = _parameters.gpio_pwm_max;
+
+				if (_gpio_ctl_high) {
+					if (pwm > high || pwm < low) {
+						_gpio_ctl_high = false;
+					}
+				} else {
+					if (pwm <= high && pwm >= low) {
+						_gpio_ctl_high = true;
+					}
+				}
+				PX4_INFO("Channel %d PWM: %d, GPIO control: %s", _parameters.gpio_rc_channel, (int)pwm, _gpio_ctl_high ? "HIGH" : "LOW");
+			}
+			else {
+				PX4_WARN("No RC input or channel count less than configured GPIO RC channel");
+			}
+			
+		}
+
 	}
 
 	if (!_outputs_on) {
@@ -1733,7 +1786,11 @@ void VoxlEsc::print_params()
 	PX4_INFO("Params: VOXL_ESC_T_WARN: %" PRId32, _parameters.esc_warn_temp_threshold);
 	PX4_INFO("Params: VOXL_ESC_T_OVER: %" PRId32, _parameters.esc_over_temp_threshold);
 
-	PX4_INFO("Params: GPIO_CTL_CH: %" PRId32, _parameters.gpio_ctl_channel);
+	// PX4_INFO("Params: GPIO_CTL_CH: %" PRId32, _parameters.gpio_ctl_channel);
+
+	PX4_INFO("Params: VOXL_ESC_GPIO_RC: %" PRId32, _parameters.gpio_rc_channel);
+	PX4_INFO("Params: VOXL_ESC_GPIO_MN: %" PRId32, _parameters.gpio_pwm_min);
+	PX4_INFO("Params: VOXL_ESC_GPIO_MX: %" PRId32, _parameters.gpio_pwm_max);
 
 	PX4_INFO("Params: VOXL_ESC_CMD: %" PRId32, _parameters.cmd_type);
 }

--- a/src/drivers/actuators/voxl_esc/voxl_esc.cpp
+++ b/src/drivers/actuators/voxl_esc/voxl_esc.cpp
@@ -307,8 +307,6 @@ int VoxlEsc::load_params(voxl_esc_params_t *params, ch_assign_t *map)
 	param_get(param_find("VOXL_ESC_T_WARN"), &params->esc_warn_temp_threshold);
 	param_get(param_find("VOXL_ESC_T_OVER"), &params->esc_over_temp_threshold);
 
-	//param_get(param_find("GPIO_CTL_CH"), &params->gpio_ctl_channel);
-
 	param_get(param_find("VOXL_ESC_GPIO_RC"), &params->gpio_rc_channel);
 	param_get(param_find("VOXL_ESC_GPIO_MN"), &params->gpio_pwm_min);
 	param_get(param_find("VOXL_ESC_GPIO_MX"), &params->gpio_pwm_max);
@@ -361,25 +359,19 @@ int VoxlEsc::load_params(voxl_esc_params_t *params, ch_assign_t *map)
 		ret = PX4_ERROR;
 	}
 
-	/*
-	if (params->gpio_ctl_channel < 0 || params->gpio_ctl_channel > 6) {
-		PX4_ERR("Invalid parameter GPIO_CTL_CH.  Please verify parameters.");
-		params->gpio_ctl_channel = 0;
-		ret = PX4_ERROR;
-	}
-	*/
+	if (params->gpio_rc_channel != -1) {
+		const bool rc_set 	= (params->gpio_rc_channel >= 1 && params->gpio_rc_channel <= 16);
+		const bool pmin_set	= (params->gpio_pwm_min >= 1000 && params->gpio_pwm_min <= 2000);
+		const bool pmax_set	= (params->gpio_pwm_max >= 1000 && params->gpio_pwm_max <= 2000);
+		const bool gpio_ctl_valid = (rc_set && pmin_set && pmax_set);
 
-	const bool rc_set 	= (params->gpio_rc_channel >= 1 && params->gpio_rc_channel <= 16);
-	const bool pmin_set	= (params->gpio_pwm_min >= 900 && params->gpio_pwm_min <= 2100);
-	const bool pmax_set	= (params->gpio_pwm_max >= 900 && params->gpio_pwm_max <= 2100);
-	const bool gpio_ctl_valid = (rc_set && pmin_set && pmax_set);
-
-	if (!gpio_ctl_valid) {
-		PX4_ERR("Invalid GPIO control parameters. To enable GPIO control, set GPIO_RC_CHANNEL to a valid RC channel (1-16) and set GPIO_PWM_MIN/MAX to valid PWM values (900-2100).  Please verify parameters.");
-		params->gpio_rc_channel = -1;
-	} else if (params->gpio_pwm_max - params->gpio_pwm_min < 2 * VOXL_ESC_GPIO_HSYT_US) {
-		PX4_ERR("Invalid GPIO PWM range. The difference between GPIO_PWM_MAX and GPIO_PWM_MIN must be at least %d us to account for hysteresis.  Please verify parameters.", 2 * VOXL_ESC_GPIO_HSYT_US);
-		params->gpio_rc_channel = -1;
+		if (!gpio_ctl_valid) {
+			PX4_ERR("Invalid GPIO control parameters. To enable GPIO control, set GPIO_RC_CHANNEL to a valid RC channel (1-16) and set GPIO_PWM_MIN/MAX to valid PWM values (1000-2000).  Please verify parameters.");
+			params->gpio_rc_channel = -1;
+		} else if (params->gpio_pwm_max - params->gpio_pwm_min < 2 * VOXL_ESC_GPIO_HSYT_US) {
+			PX4_ERR("Invalid GPIO PWM range. The difference between GPIO_PWM_MAX and GPIO_PWM_MIN must be at least %d us to account for hysteresis.  Please verify parameters.", 2 * VOXL_ESC_GPIO_HSYT_US);
+			params->gpio_rc_channel = -1;
+		}
 	}
 
 	for (int i = 0; i < VOXL_ESC_OUTPUT_CHANNELS; i++) {
@@ -1565,42 +1557,6 @@ void VoxlEsc::Run()
 
 		}
 
-		// check if gpio control is enabled
-		/*
-		if (_parameters.gpio_ctl_channel > 0) {
-
-			_gpio_ctl_en = true;
-			float gpio_setpoint = VOXL_ESC_GPIO_CTL_DISABLED_SETPOINT;
-
-			switch (_parameters.gpio_ctl_channel) {
-				case VOXL_ESC_GPIO_CTL_AUX1:
-					gpio_setpoint = _manual_control_setpoint.aux1;
-					break;
-				case VOXL_ESC_GPIO_CTL_AUX2:
-					gpio_setpoint = _manual_control_setpoint.aux2;
-					break;
-				case VOXL_ESC_GPIO_CTL_AUX3:
-					gpio_setpoint = _manual_control_setpoint.aux3;
-					break;
-				case VOXL_ESC_GPIO_CTL_AUX4:
-					gpio_setpoint = _manual_control_setpoint.aux4;
-					break;
-				case VOXL_ESC_GPIO_CTL_AUX5:
-					gpio_setpoint = _manual_control_setpoint.aux5;
-					break;
-				case VOXL_ESC_GPIO_CTL_AUX6:
-					gpio_setpoint = _manual_control_setpoint.aux6;
-					break;
-			}
-
-			if (gpio_setpoint > VOXL_ESC_GPIO_CTL_THRESHOLD) {
-				_gpio_ctl_high = false;
-			} else {
-				_gpio_ctl_high = true;
-			}
-
-		}
-		*/
 
 		if (_parameters.gpio_rc_channel > 0) {
 			_gpio_ctl_en = true;

--- a/src/drivers/actuators/voxl_esc/voxl_esc.hpp
+++ b/src/drivers/actuators/voxl_esc/voxl_esc.hpp
@@ -50,6 +50,7 @@
 #include <uORB/topics/esc_status.h>
 #include <uORB/topics/actuator_test.h>
 #include <uORB/topics/mavlink_tunnel.h>
+#include <uORB/topics/input_rc.h>
 
 #include "voxl_esc_serial.hpp"
 
@@ -134,7 +135,8 @@ private:
 
 	static constexpr uint16_t VOXL_ESC_NUM_INIT_RETRIES = 3;
 
-	static constexpr float    VOXL_ESC_GPIO_CTL_DISABLED_SETPOINT = -0.1f;
+	// static constexpr float    VOXL_ESC_GPIO_CTL_DISABLED_SETPOINT = -0.1f;
+	static constexpr int32_t	VOXL_ESC_GPIO_HSYT_US = 10;
 	static constexpr float    VOXL_ESC_GPIO_CTL_THRESHOLD = 0.0f;
 
 	static constexpr uint32_t VOXL_ESC_GPIO_CTL_AUX1 = 1;
@@ -171,7 +173,10 @@ private:
 		int32_t		publish_battery_status{0};
 		int32_t		esc_warn_temp_threshold{0};
 		int32_t		esc_over_temp_threshold{0};
-		int32_t		gpio_ctl_channel{0};
+		// int32_t		gpio_ctl_channel{0};
+		int32_t		gpio_rc_channel{-1};
+		int32_t		gpio_pwm_min{-1};
+		int32_t 	gpio_pwm_max{-1};
 		int32_t		cmd_type{0};
 	} voxl_esc_params_t;
 
@@ -218,6 +223,7 @@ private:
 	uORB::Subscription	_actuator_test_sub{ORB_ID(actuator_test)};
 	uORB::Subscription	_led_update_sub{ORB_ID(led_control)};
 	uORB::Subscription	_esc_serial_passthru_sub{ORB_ID(esc_serial_passthru)};
+	uORB::Subscription	_input_rc_sub{ORB_ID(input_rc)};
 
 	uORB::Publication<actuator_outputs_s> _outputs_debug_pub{ORB_ID(actuator_outputs_debug)};
 	uORB::Publication<esc_status_s> _esc_status_pub{ORB_ID(esc_status)};

--- a/src/drivers/actuators/voxl_esc/voxl_esc.hpp
+++ b/src/drivers/actuators/voxl_esc/voxl_esc.hpp
@@ -135,7 +135,6 @@ private:
 
 	static constexpr uint16_t VOXL_ESC_NUM_INIT_RETRIES = 3;
 
-	// static constexpr float    VOXL_ESC_GPIO_CTL_DISABLED_SETPOINT = -0.1f;
 	static constexpr int32_t	VOXL_ESC_GPIO_HSYT_US = 10;
 	static constexpr float    VOXL_ESC_GPIO_CTL_THRESHOLD = 0.0f;
 
@@ -173,7 +172,6 @@ private:
 		int32_t		publish_battery_status{0};
 		int32_t		esc_warn_temp_threshold{0};
 		int32_t		esc_over_temp_threshold{0};
-		// int32_t		gpio_ctl_channel{0};
 		int32_t		gpio_rc_channel{-1};
 		int32_t		gpio_pwm_min{-1};
 		int32_t 	gpio_pwm_max{-1};

--- a/src/drivers/actuators/voxl_esc/voxl_esc_params.c
+++ b/src/drivers/actuators/voxl_esc/voxl_esc_params.c
@@ -276,19 +276,6 @@ PARAM_DEFINE_INT32(VOXL_ESC_T_OVER, 0);
 PARAM_DEFINE_INT32(VOXL_ESC_T_ON, 9);
 
 /**
- * GPIO Control Channel
- *
- *
- * @reboot_required true
- *
- * @group VOXL_ESC
- * @value 0 - Disabled
- * @min 0
- * @max 6
- */
-// PARAM_DEFINE_INT32(GPIO_CTL_CH, 0);
-
-/**
  * GPIO RC Channel index
  * 
  * -1 disables this feature

--- a/src/drivers/actuators/voxl_esc/voxl_esc_params.c
+++ b/src/drivers/actuators/voxl_esc/voxl_esc_params.c
@@ -286,7 +286,43 @@ PARAM_DEFINE_INT32(VOXL_ESC_T_ON, 9);
  * @min 0
  * @max 6
  */
-PARAM_DEFINE_INT32(GPIO_CTL_CH, 0);
+// PARAM_DEFINE_INT32(GPIO_CTL_CH, 0);
+
+/**
+ * GPIO RC Channel index
+ * 
+ * -1 disables this feature
+ * 
+ * @group VOXL ESC
+ * @min -1
+ * @max 18
+ */
+PARAM_DEFINE_INT32(VOXL_ESC_GPIO_RC, -1);
+
+/**
+ * Lower PWM Bound for in-range window for GPIO control
+ * 
+ * Feature inert until set to a positive value
+ * 
+ * @group VOXL ESC
+ * @unit us
+ * @min -1
+ * @max 2100
+ */
+PARAM_DEFINE_INT32(VOXL_ESC_GPIO_MN, -1);
+
+/**
+ * Upper PWM Bound for in-range window for GPIO control
+ * 
+ * Must be set higher than VOXL_ESC_GPIO_PMIN by 20us for valid window.
+ * Feature inert until set to a positive value
+ * 
+ * @group VOXL ESC
+ * @unit us
+ * @min -1
+ * @max 2100
+ */
+PARAM_DEFINE_INT32(VOXL_ESC_GPIO_MX, -1);
 
 /**
  * UART ESC command type


### PR DESCRIPTION
Allows for multiple VTXs to be controlled by the same channel on a controller (Drones on a switch).

Created 3 new parameters: RC Channel for gpio control, channel min value, and channel max value.

The changed logic is now for the driver to source the rc channel uorb topic and assess the rc channel for gpio control. If the channel's value is between the rc min and rc max param, the gpio is set high. If the channel value is outside of the set range, the gpio is set low.

All three new parameters default values are set to -1.

